### PR TITLE
[Migration-prefect] rj-sme.educacao_basica.avaliacao

### DIFF
--- a/pipelines/rj_sme__educacao_basica/flow.py
+++ b/pipelines/rj_sme__educacao_basica/flow.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Register flow 27/06/2024 - 15:09
 """
 This flow is used to dump the database to the BIGQUERY
 """

--- a/pipelines/rj_sme__educacao_basica/prefect.yaml
+++ b/pipelines/rj_sme__educacao_basica/prefect.yaml
@@ -375,3 +375,48 @@ deployments:
             [Tot_Mov],
             [alu_id]
           FROM GestaoEscolar.dbo.VW_BI_Movimentacao_lgpd
+
+# Schedule para tabela Avaliação (append com particionamento por ano)
+    - interval: 86400
+      anchor_date: "2022-01-01T02:10:00"
+      timezone: America/Sao_Paulo
+      slug: avaliacao
+      parameters:
+        table_id: avaliacao
+        dump_mode: append
+        partition_columns: Ano
+        partition_date_format: "%Y"
+        break_query_frequency: year
+        break_query_start: current_year
+        break_query_end: current_year
+        execute_query: |
+            SELECT
+                [Ano],
+                [COC],
+                [tpc_nome],
+                [tur_codigo],
+                [Reunião_Pais],
+                [Frequencia],
+                [Conceito],
+                [GLB],
+                [MAT],
+                [POR],
+                [CIE],
+                [GEO],
+                [HIS],
+                [EFI],
+                [ING],
+                [ESP],
+                [FRA],
+                [ALE],
+                [AVI],
+                [APL],
+                [ACE],
+                [TEA],
+                [MUS],
+                [cur_id],
+                [crp_id],
+                [tur_id],
+                [alu_id],
+                [mtu_id]
+            FROM GestaoEscolar.dbo.VW_BI_Avaliacao


### PR DESCRIPTION
Migrando a pipeline de `educacao_basica.avaliacao` da `Secretaria Municipal de Educação` para o Prefect 3
Algumas pipelines já tinham sido migradas, apenas acrescentei os modelso no schedules no arquivo `prefect.yaml`, seguindo os seguintes requisitos: https://github.com/prefeitura-rio/pipelines_rj_sme/blob/main/pipelines/educacao_basica/dump_db/flows.py

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Adicionada nova configuração de agendamento para processamento de dados de avaliação educacional com particionamento anual.

* **Chores**
  * Adicionada informação de registro com timestamp na configuração do pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->