### PR TITLE
fix(disparo): prevent IndexError when others array is empty

### DIFF
--- a/pipelines/rj_crm__disparo_template/utils/dispatch.py
+++ b/pipelines/rj_crm__disparo_template/utils/dispatch.py
@@ -953,13 +953,19 @@ def get_retry_destinations(
         ext_id = get_value_from_case_insensitive_key(dest, 'externalId')
         others = get_value_from_case_insensitive_key(dest, 'others') or []
         to_number = get_value_from_case_insensitive_key(dest, 'to')
-        print(f"DEBUG dest {dest}")
+        log(f"DEBUG dest {dest}")
 
-        if (ext_id is None or str(ext_id) in failed_ids or to_number is None) and attempt_number > 0 and len(others) >= attempt_number:
+        # Condições de elegibilidade para retry: telefone faltando/inválido + retry attempt válido
+        is_ext_missing = (ext_id is None)
+        is_failed_id = (str(ext_id) in failed_ids)
+        is_to_number_missing = (to_number is None)
+        can_retry = (attempt_number > 0 and len(others) >= attempt_number)
+
+        if (is_ext_missing or is_failed_id or is_to_number_missing) and can_retry:
             new_dest = dest.copy()
             # Atualiza o campo 'to' com o número da repescagem (tentativa 1 pega others[0])
             new_dest['to'] = others[attempt_number - 1]
-            print(f"DEBUG: new_dest alterado = {new_dest}")
+            log(f"DEBUG: new_dest alterado = {new_dest}")
             retry_destinations.append(new_dest)
         elif attempt_number == 0:
             retry_destinations.append(dest)            

--- a/pipelines/rj_crm__disparo_template/utils/dispatch.py
+++ b/pipelines/rj_crm__disparo_template/utils/dispatch.py
@@ -955,7 +955,7 @@ def get_retry_destinations(
         to_number = get_value_from_case_insensitive_key(dest, 'to')
         print(f"DEBUG dest {dest}")
 
-        if (ext_id is None or str(ext_id) in failed_ids or to_number is None) and len(others) >= attempt_number:
+        if (ext_id is None or str(ext_id) in failed_ids or to_number is None) and attempt_number > 0 and len(others) >= attempt_number:
             new_dest = dest.copy()
             # Atualiza o campo 'to' com o número da repescagem (tentativa 1 pega others[0])
             new_dest['to'] = others[attempt_number - 1]


### PR DESCRIPTION
## Problema

Flow de disparo SMS para puérperas (HSM 588 - D1/D3/D5/D10) estava crasheando desde 23/05/2026 com `IndexError: list index out of range`.

### Causa Raiz
Quando uma puérpera tinha:
- Telefone principal que falhou (`to: None`)
- Nenhum telefone alternativo (`others: []`)

O código tentava acessar `others[attempt_number - 1]` com `attempt_number = 0`, resultando em `others[-1]` em lista vazia.

## Solução

Adicionada condição `attempt_number > 0` na linha 958 de `dispatch.py`:

```python
# ANTES
if (ext_id is None or str(ext_id) in failed_ids or to_number is None) and len(others) >= attempt_number:

# DEPOIS
if (ext_id is None or str(ext_id) in failed_ids or to_number is None) and attempt_number > 0 and len(others) >= attempt_number:
```

## Impacto

### Comportamento Mantido
- ✅ Todos os retries (attempt_number >= 1) funcionam **exatamente como antes**
- ✅ Nenhuma mudança em lógica de telefones alternativos

### Bugs Corrigidos
1. **Crítico**: Previne crash quando `attempt_number=0` e `others=[]`
2. **Secundário**: Corrige comportamento incorreto quando `attempt_number=0` com `others` não vazio (pegava `others[-1]` ao invés do destino original)

## Validação

- [x] Análise de impacto completa em `analyses/FIX_IMPACT_ANALYSIS.md`
- [x] Matriz de comportamento validada para todos os cenários
- [x] Sem regressão identificada

## Puérperas Afetadas

~27 puérperas não receberam mensagens nos últimos 3 dias (23-25/05). Após merge e deploy, executar manualmente flows para esses dias.

## Referências

- Bug Report: `analyses/BUG_REPORT_D1_IndexError.md`
- Impact Analysis: `analyses/FIX_IMPACT_ANALYSIS.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrigido comportamento na lógica de retentativas de disparo que causava erro em cenários específicos de tentativa inicial, garantindo que os destinos sejam processados corretamente.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prefeitura-rio/prefect_rj_iplanrio/pull/258?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->