### PR TITLE
[Migration-Prefect-V3] rj-pgm.divida_ativa

### DIFF
--- a/pipelines/rj_pgm__divida_ativa/flow.py
+++ b/pipelines/rj_pgm__divida_ativa/flow.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 """
-This flow is used to dump the database from the 1746 server to the BIGQUERY....
+Flow de ingestão de dados do sistema DAM (Dívida Ativa Municipal) da PGM.
+
+Este módulo implementa um flow do Prefect 3.0 para extrair dados do banco de dados
+SQL Server do sistema de Dívida Ativa Municipal e carregar no BigQuery, utilizando
+particionamento e processamento em lotes para otimização de performance.
 """
 
 from typing import Optional
@@ -43,6 +47,81 @@ def rj_pgm__divida_ativa(
     only_staging_dataset: bool = False,
     add_timestamp_column: bool = True,
 ):
+    """
+    Flow principal para ingestão de dados de Dívida Ativa Municipal no BigQuery.
+
+    Este flow realiza a extração de dados do banco SQL Server do sistema DAM (Dívida Ativa
+    Municipal) da Procuradoria Geral do Município e carrega os dados no BigQuery. O processo
+    inclui autenticação via Infisical, formatação de queries com particionamento opcional,
+    e upload em lotes para otimizar performance e uso de memória.
+
+    Args:
+        db_database: Nome do banco de dados no SQL Server.
+            Default: "DAM_PRD"
+        db_host: Endereço IP ou hostname do servidor SQL Server.
+            Default: "10.2.221.127"
+        db_port: Porta de conexão do SQL Server.
+            Default: "1433"
+        db_type: Tipo do banco de dados (sql_server, mysql, postgres, etc).
+            Default: "sql_server"
+        db_charset: Charset a ser utilizado na conexão. Use "NOT_SET" para não especificar.
+            Default: "NOT_SET"
+        execute_query: Query SQL a ser executada para extração dos dados.
+            Default: "execute_query"
+        dataset_id: ID do dataset no BigQuery onde os dados serão carregados.
+            Default: "brutos_divida_ativa"
+        table_id: ID da tabela no BigQuery onde os dados serão carregados.
+            Default: "table_id"
+        infisical_secret_path: Caminho do secret no Infisical contendo credenciais do banco.
+            Default: "/db-divida-ativa"
+        dump_mode: Modo de carga dos dados ("overwrite" para substituir, "append" para adicionar).
+            Default: "overwrite"
+        partition_date_format: Formato de data para particionamento (ex: "%Y-%m-%d", "%Y").
+            Default: "%Y-%m-%d"
+        partition_columns: Colunas a serem usadas para particionamento, separadas por vírgula.
+            Default: None
+        lower_bound_date: Data limite inferior para queries particionadas (ex: "2020-01-01").
+            Suporta valores especiais como "current_year".
+            Default: None
+        break_query_frequency: Frequência de quebra da query para processamento incremental
+            (ex: "1D" para diário, "1M" para mensal).
+            Default: None
+        break_query_start: Data inicial para quebra incremental de queries.
+            Default: None
+        break_query_end: Data final para quebra incremental de queries.
+            Default: None
+        retry_dump_upload_attempts: Número de tentativas de retry em caso de falha no upload.
+            Default: 3
+        batch_size: Tamanho do lote para processamento (número de linhas por batch).
+            Default: 50000
+        batch_data_type: Formato dos dados em lote ("csv" ou "parquet").
+            Default: "csv"
+        biglake_table: Se True, cria tabela como BigLake table para acesso externo.
+            Default: True
+        log_number_of_batches: Intervalo de batches para logging de progresso.
+            Default: 100
+        max_concurrency: Número máximo de uploads concorrentes.
+            Default: 1
+        only_staging_dataset: Se True, carrega apenas no dataset de staging (não em produção).
+            Default: False
+        add_timestamp_column: Se True, adiciona coluna com timestamp da ingestão.
+            Default: True
+
+    Returns:
+        None. O flow executa as tasks de ingestão e upload sem retorno explícito.
+
+    Example:
+        >>> # Exemplo de execução via schedule no prefect.yaml:
+        >>> # parameters:
+        >>> #   table_id: CDA
+        >>> #   execute_query: SELECT * FROM DAM_PRD.dbo.CDA
+
+    Notes:
+        - As credenciais de acesso ao banco são obtidas via Infisical
+        - O flow injeta automaticamente as credenciais do BD no ambiente
+        - O nome do flow run é renomeado para o table_id para facilitar monitoramento
+        - Suporta particionamento por data com diferentes formatos e frequências
+    """
     rename_current_flow_run_task(new_name=table_id)
     inject_bd_credentials_task(environment="prod")
     secrets = get_database_username_and_password_from_secret_task(infisical_secret_path=infisical_secret_path)

--- a/pipelines/rj_pgm__divida_ativa/prefect.yaml
+++ b/pipelines/rj_pgm__divida_ativa/prefect.yaml
@@ -409,17 +409,20 @@ deployments:
       timezone: America/Sao_Paulo
       slug: inscritos_divida_ativa
       parameters:
-        table_id: inscritos_divida_ativa
-        dump_mode: append
-        partition_columns: anoInscricao
-        partition_date_format: "%Y"
-        lower_bound_date: current_year
-        execute_query: |
-          SELECT
-            Nome,
-            Cpf_Cnpj,
-            Cpf_Cnpj_formatado,
-            anoInscricao,
-            valDebito,
-            ultima_atualizacao
-          FROM DAM_PRD.dbo.vwInscritosDividaAtiva
+              table_id: inscritos_divida_ativa
+              dump_mode: append
+              partition_columns: anoInscricao
+              partition_date_format: "%Y"
+              lower_bound_date: current_year
+              break_query_frequency: year
+              break_query_end: current_year
+              break_query_start: current_year
+              execute_query: |
+                SELECT
+                  Nome,
+                  Cpf_Cnpj,
+                  Cpf_Cnpj_formatado,
+                  anoInscricao,
+                  valDebito,
+                  ultima_atualizacao
+                FROM DAM_PRD.dbo.vwInscritosDividaAtiva

--- a/pipelines/rj_pgm__divida_ativa/prefect.yaml
+++ b/pipelines/rj_pgm__divida_ativa/prefect.yaml
@@ -404,3 +404,22 @@ deployments:
             ValMoraJurosPG,
             ValPrincipalPG
           FROM DAM_PRD.dbo.PagamentosCDA
+    - interval: 86400
+      anchor_date: "2022-01-01T03:00:00"
+      timezone: America/Sao_Paulo
+      slug: inscritos_divida_ativa
+      parameters:
+        table_id: inscritos_divida_ativa
+        dump_mode: append
+        partition_columns: anoInscricao
+        partition_date_format: "%Y"
+        lower_bound_date: current_year
+        execute_query: |
+          SELECT
+            Nome,
+            Cpf_Cnpj,
+            Cpf_Cnpj_formatado,
+            anoInscricao,
+            valDebito,
+            ultima_atualizacao
+          FROM DAM_PRD.dbo.vwInscritosDividaAtiva

--- a/pipelines/rj_smdue__dump_db_sislic/prefect.yaml
+++ b/pipelines/rj_smdue__dump_db_sislic/prefect.yaml
@@ -1038,25 +1038,25 @@ deployments:
                 ,Cancelado
                 ,Obs
             FROM SMU_PRD.dbo.tbLIC_Aceitacoes
-      - interval: 86400
-        anchor_date: "2022-12-19T06:05:00"
-        timezone: America/Sao_Paulo
-        slug: georeferencia_endereco_obra_processo
-        parameters:
-          table_id: georeferencia_endereco_obra_processo
-          execute_query: |
-            SELECT
-            id_processo,
-            id_processo_sislic,
-            nu_processo,
-            cd_logradouro,
-            nu_porta,
-            nu_pal,
-            id_bairro_sislic,
-            id_ra_sislic,
-            no_bairro,
-            shape
-            FROM SMU_PRD.dbo.tbGEOSISLIC_processo
+      # - interval: 86400
+      #   anchor_date: "2022-12-19T06:05:00"
+      #   timezone: America/Sao_Paulo
+      #   slug: georeferencia_endereco_obra_processo
+      #   parameters:
+      #     table_id: georeferencia_endereco_obra_processo
+      #     execute_query: |
+      #       SELECT
+      #       id_processo,
+      #       id_processo_sislic,
+      #       nu_processo,
+      #       cd_logradouro,
+      #       nu_porta,
+      #       nu_pal,
+      #       id_bairro_sislic,
+      #       id_ra_sislic,
+      #       no_bairro,
+      #       shape
+      #       FROM SMU_PRD.dbo.tbGEOSISLIC_processo
       - interval: 86400
         anchor_date: "2022-12-19T06:10:00"
         timezone: America/Sao_Paulo


### PR DESCRIPTION
Migrando a pipeline rj-pgm.divida_ativa.
- Testado em staging e subindo as partições retroativas desde 1973: https://prefect.squirrel-regulus.ts.net/runs/flow-run/8edc88f2-2124-4298-a738-87d9e0482c18

Desativando a pipeline de sislic.georeferencia_endereco_obra_processo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documentação expandida do fluxo de ingestão e carregamento, com explicações e parâmetros detalhados.

* **New Features**
  * Novo agendamento diário para sincronização de inscritos da Dívida Ativa.

* **Chores**
  * Correção de uma consulta em agendamento existente.
  * Desativação de um agendamento não utilizado.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prefeitura-rio/prefect_rj_iplanrio/pull/259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->