### PR TITLE
fix(puerperas): prevent retry with duplicate phone number

### DIFF
--- a/pipelines/rj_crm__disparo_template/scheduler.yaml
+++ b/pipelines/rj_crm__disparo_template/scheduler.yaml
@@ -143,7 +143,7 @@ x-templates:
                     data_alta_internacao as CC_WT_DATA_ALTA,
                     date_diff(current_date("America/Sao_Paulo"), data_alta_internacao, day) as CC_WT_DIAS_DESDE_ALTA
                 ) AS vars,
-                ARRAY(SELECT x FROM UNNEST([celular_disparo_2, celular_disparo_3]) AS x WHERE x IS NOT NULL) AS others,
+                ARRAY(SELECT x FROM UNNEST([celular_disparo_2, celular_disparo_3]) AS x WHERE x IS NOT NULL AND x != celular_disparo) AS others,
                 CAST(cpf AS STRING) AS externalId
                 )
             ) AS destination_data
@@ -1272,7 +1272,7 @@ schedules:
                                 TIME(data_hora_agendamento_visita_maternidade) as HORA,
                                 time(data_hora_agendamento_visita_maternidade) as CC_WT_HORA
                             ) AS vars,
-                            ARRAY(SELECT x FROM UNNEST([celular_disparo_2, celular_disparo_3]) AS x WHERE x IS NOT NULL) AS others,
+                            ARRAY(SELECT x FROM UNNEST([celular_disparo_2, celular_disparo_3]) AS x WHERE x IS NOT NULL AND x != celular_disparo) AS others,
                             CAST(cpf AS STRING) AS externalId
                             )
                         ) AS destination_data
@@ -1437,7 +1437,7 @@ schedules:
                                 ) AS CC_WT_NOME,
                                 cpf AS CC_WT_CPF_CIDADAO
                             ) AS vars,
-                            ARRAY(SELECT x FROM UNNEST([celular_disparo_2, celular_disparo_3]) AS x WHERE x IS NOT NULL) AS others,
+                            ARRAY(SELECT x FROM UNNEST([celular_disparo_2, celular_disparo_3]) AS x WHERE x IS NOT NULL AND x != celular_disparo) AS others,
                             CAST(cpf AS STRING) AS externalId
                             )
                         ) AS destination_data


### PR DESCRIPTION
## Problema

Sistema de retry estava tentando enviar mensagens usando o **mesmo telefone duas vezes**, resultando em disparos duplicados que falhavam.

## Causa Raiz

Array `others` incluía o telefone principal (`celular_disparo_2`) quando `celular_disparo_1` estava NULL. Retry tentava usar `others[0]` que era o mesmo número já usado no primeiro attempt.

**Exemplo antes do fix:**
- `to`: 5521XXXXXXXXX (celular_disparo_2)
- `others`: [5521XXXXXXXXX] ← DUPLICADO!
- Retry attempt 1 → usa `others[0]` → mesmo número → FALHA

## Solução

Adicionar filtro `x != celular_disparo` na montagem do array `others` para garantir que telefones de retry sejam sempre diferentes do principal.

**Mudança aplicada:**
```sql
-- ANTES
ARRAY(SELECT x FROM UNNEST([celular_disparo_2, celular_disparo_3]) AS x WHERE x IS NOT NULL) AS others

-- DEPOIS
ARRAY(SELECT x FROM UNNEST([celular_disparo_2, celular_disparo_3]) AS x WHERE x IS NOT NULL AND x != celular_disparo) AS others
```

**Exemplo após fix:**
- `to`: 5521XXXXXXXXX
- `others`: [] ← filtrado corretamente
- Retry não tenta pois não há telefone alternativo válido

## Evidências

Casos confirmados de duplicatas (8 min de intervalo entre disparos):
- CPF 199126XXXXX: 2 disparos HSM 610 em 22/05
- CPF 118310XXXXX: 2 disparos HSM 573 em 28/04
- CPF 219030XXXXX: 2 disparos HSM 573 em 29/04

## Validação

✅ Teste realizado no BigQuery confirma que fix resolve o problema:
- `tem_duplicata_apos_fix = FALSE`

## Impacto

- ✅ Previne disparos duplicados com mesmo telefone
- ✅ Não altera comportamento quando há telefones alternativos válidos
- ✅ Fix conservador: mantém lógica original, apenas adiciona filtro

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Correções
- Corrigido problema de duplicação de números de telefone nas tentativas de confirmação de agendamento. O número de telefone principal agora é automaticamente excluído da lista de números alternativos, prevenindo tentativas de contato redundantes e otimizando o fluxo de recontatos do sistema.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prefeitura-rio/prefect_rj_iplanrio/pull/262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->