### PR TITLE
fix: correct puerpera schedules to use cron (D0 at 14h, others at 10h)

### DIFF
--- a/pipelines/rj_crm__disparo_template/scheduler.yaml
+++ b/pipelines/rj_crm__disparo_template/scheduler.yaml
@@ -1104,8 +1104,7 @@ schedules:
         where rn=1
 
   # Disparo SMS Puérperas Confirmação agendamento
-  - interval: 86400
-    anchor_date: "2021-01-01T15:00:00"
+  - cron: "0 10 * * *"
     timezone: America/Sao_Paulo
     active: true
     slug: daily-sms-puerpera-confirma-agendamento
@@ -1280,8 +1279,7 @@ schedules:
                 where celular_disparo is not null
 
   # Disparo SMS Puérperas D0 - Explicação do processo
-  - interval: 3600
-    anchor_date: "2021-01-01T15:10:00"
+  - cron: "0 14 * * *"
     timezone: America/Sao_Paulo
     active: true
     slug: daily-sms-puerperas-d0
@@ -1445,8 +1443,7 @@ schedules:
                 where celular_disparo is not null
 
   # Disparo SMS Puérperas D1, D3, D5 e D10 - Pesquisa 1
-  - interval: 86400
-    anchor_date: "2021-01-01T15:20:00"
+  - cron: "0 10 * * *"
     timezone: America/Sao_Paulo
     active: true
     slug: daily-sms-puerperas-d1-d3-d5-d10
@@ -1485,8 +1482,7 @@ schedules:
         query: *puerperas_query_template
 
   # Disparo SMS Puérperas D7 - Pesquisa 2
-  - interval: 86400
-    anchor_date: "2021-01-01T15:20:00"
+  - cron: "0 10 * * *"
     timezone: America/Sao_Paulo
     active: true
     slug: daily-sms-puerperas-d7
@@ -1521,8 +1517,7 @@ schedules:
         query: *puerperas_query_template
 
   # Disparo SMS Puérperas D13, D16 e D19 - Pesquisa 3
-  - interval: 86400
-    anchor_date: "2021-01-01T15:20:00"
+  - cron: "0 10 * * *"
     timezone: America/Sao_Paulo
     active: true
     slug: daily-sms-puerperas-d13-d16-d19
@@ -1560,8 +1555,7 @@ schedules:
         query: *puerperas_query_template
 
   # Disparo SMS Puérperas D22 - Pesquisa 4
-  - interval: 86400
-    anchor_date: "2021-01-01T15:20:00"
+  - cron: "0 10 * * *"
     timezone: America/Sao_Paulo
     active: true
     slug: daily-sms-puerperas-d22
@@ -1596,8 +1590,7 @@ schedules:
         query: *puerperas_query_template
 
   # Disparo SMS Puérperas D25 e D28 - Pesquisa 5
-  - interval: 86400
-    anchor_date: "2021-01-01T15:20:00"
+  - cron: "0 10 * * *"
     timezone: America/Sao_Paulo
     active: true
     slug: daily-sms-puerperas-d25-d28
@@ -1634,8 +1627,7 @@ schedules:
         query: *puerperas_query_template
 
   # Disparo SMS Puérperas D34 - Pesquisa 6
-  - interval: 86400
-    anchor_date: "2021-01-01T15:20:00"
+  - cron: "0 10 * * *"
     timezone: America/Sao_Paulo
     active: true
     slug: daily-sms-puerperas-d34
@@ -1670,8 +1662,7 @@ schedules:
         query: *puerperas_query_template
 
  # Disparo SMS Puérperas D40 - Pesquisa 7
-  - interval: 86400
-    anchor_date: "2021-01-01T15:20:00"
+  - cron: "0 10 * * *"
     timezone: America/Sao_Paulo
     active: true
     slug: daily-sms-puerperas-d40


### PR DESCRIPTION
## Resumo

Corrige os schedules dos disparos de puérperas para usar `cron` ao invés de `interval`, garantindo execução em horários fixos que não mudam após deploys.

## Mudanças

### Schedule D0 (HSM 610)
- **Antes**: `interval: 3600` (a cada 1 hora) + `anchor_date: 15:10`
- **Depois**: `cron: "0 14 * * *"` (1x/dia às 14h)

### Schedule Confirma-Agendamento (HSM 573)
- **Antes**: `interval: 86400` (24h) + `anchor_date: 15:00`
- **Depois**: `cron: "0 10 * * *"` (1x/dia às 10h)

### Outros Schedules (D1-D3-D5-D10, D7, D13-D16-D19, D22, D25-D28, D34, D40)
- **Antes**: `interval: 86400` (24h) + `anchor_date: 15:20`
- **Depois**: `cron: "0 10 * * *"` (1x/dia às 10h)

## Impacto

⚠️ **ATENÇÃO - Mudanças de comportamento:**

1. **D0 muda drasticamente**: de execução **a cada hora** para **1x por dia às 14h**
2. **Horários adiantados**: execuções que eram às 15h/15:20 agora rodam às 10h (5+ horas mais cedo)

## Benefícios

✅ Horários fixos que não mudam após deploys
✅ Usa `cron` conforme recomendação do Prefect para horários específicos
✅ Mais previsível e fácil de monitorar

## Checklist

- [x] Schedules modificados: 9 no total
- [x] Sintaxe cron validada
- [x] Timezone mantido: `America/Sao_Paulo`
- [ ] Verificar no Prefect UI após merge

🤖 Generated with Claude Code