### PR TITLE
[fix] Corrige disparos duplicados de puérperas (janela de dedupe)

### DIFF
--- a/pipelines/rj_crm__disparo_template/prefect.yaml
+++ b/pipelines/rj_crm__disparo_template/prefect.yaml
@@ -1380,7 +1380,7 @@ deployments:
               DATE_ADD(DATE(data_alta_internacao), INTERVAL 3 DAY),
               DATE_ADD(DATE(data_alta_internacao), INTERVAL 5 DAY),
               DATE_ADD(DATE(data_alta_internacao), INTERVAL 10 DAY)
-            intervalo_filtro_disparados: 1
+            intervalo_filtro_disparados: 300
           table_id: disparos_efetuados
           dump_mode: append
           test_mode: false
@@ -1603,7 +1603,7 @@ deployments:
               DATE_ADD(DATE(data_alta_internacao), INTERVAL 13 DAY),
               DATE_ADD(DATE(data_alta_internacao), INTERVAL 16 DAY),
               DATE_ADD(DATE(data_alta_internacao), INTERVAL 19 DAY)
-            intervalo_filtro_disparados: 1
+            intervalo_filtro_disparados: 300
           table_id: disparos_efetuados
           dump_mode: append
           test_mode: false
@@ -1675,7 +1675,7 @@ deployments:
             datas_internacao: |
               DATE_ADD(DATE(data_alta_internacao), INTERVAL 25 DAY),
               DATE_ADD(DATE(data_alta_internacao), INTERVAL 28 DAY)
-            intervalo_filtro_disparados: 1
+            intervalo_filtro_disparados: 300
           table_id: disparos_efetuados
           dump_mode: append
           test_mode: false

--- a/pipelines/rj_crm__disparo_template/scheduler.yaml
+++ b/pipelines/rj_crm__disparo_template/scheduler.yaml
@@ -1460,7 +1460,7 @@ schedules:
                 DATE_ADD(DATE(data_alta_internacao), INTERVAL 3 DAY),
                 DATE_ADD(DATE(data_alta_internacao), INTERVAL 5 DAY),
                 DATE_ADD(DATE(data_alta_internacao), INTERVAL 10 DAY)
-            intervalo_filtro_disparados: 1
+            intervalo_filtro_disparados: 300
         table_id: disparos_efetuados
         dump_mode: append
         test_mode: false
@@ -1533,7 +1533,7 @@ schedules:
                 DATE_ADD(DATE(data_alta_internacao), INTERVAL 13 DAY),
                 DATE_ADD(DATE(data_alta_internacao), INTERVAL 16 DAY),
                 DATE_ADD(DATE(data_alta_internacao), INTERVAL 19 DAY)
-            intervalo_filtro_disparados: 1
+            intervalo_filtro_disparados: 300
         table_id: disparos_efetuados
         dump_mode: append
         test_mode: false
@@ -1605,7 +1605,7 @@ schedules:
             datas_internacao: |
                 DATE_ADD(DATE(data_alta_internacao), INTERVAL 25 DAY),
                 DATE_ADD(DATE(data_alta_internacao), INTERVAL 28 DAY)
-            intervalo_filtro_disparados: 1
+            intervalo_filtro_disparados: 300
         table_id: disparos_efetuados
         dump_mode: append
         test_mode: false


### PR DESCRIPTION
## Problema

As HSMs de pesquisa de puérperas que disparam a **mesma mensagem em vários dias-desde-alta** estavam reenviando para o mesmo CPF:

| id_hsm | nome_hsm | dias-alvo | duplicatas (90d) |
|--------|----------|-----------|------------------|
| 588 | sms-puerperas-disparo4-v3 | D1/D3/D5/D10 | **77** |
| 562 | sms-puerperas-disparo9 | D13/D16/D19 | **23** |
| 564 | sms-puerperas-disparo12 | D25/D28 | latente |

## Causa-raiz

O CTE `filtra_disparados` usa janela `intervalo_filtro_disparados` em dias. Estava em **`1`**, menor que o espaçamento entre os dias-alvo (2–5 dias). Resultado: o envio anterior cai **fora** da janela de 1 dia e a pessoa recebe a mesma HSM em cada dia-alvo.

## Evidência (BQ — `rj-crm-registry.rmi_conversas.chatbot`)

- **100% das duplicatas em dias diferentes** (zero no mesmo dia → não é retry loop nem whitelist).
- Gaps batem exatamente com `datas_internacao`: 562 → todos com 3 dias; 588 → 2 e 5 dias.
- **Simulação retroativa do filtro** sobre envios reais:

  | HSM | reenvios | bloqueados c/ 1 dia | bloqueados c/ 300 dias |
  |-----|----------|---------------------|------------------------|
  | 562 | 34 | 10 | **34 (100%)** |
  | 588 | 87 | 41 | **87 (100%)** |

## Mudança

`intervalo_filtro_disparados: 1 → 300` nos 3 blocos multi-dia (588, 562, 564) em `scheduler.yaml`, alinhando ao valor já usado nas HSMs de dia único. `prefect.yaml` regenerado via `build_prefect_yaml.py --env prod`.

## Fora de escopo

**HSM 573** (`sms_puerpera_disp1_gestante-v2`, confirma agendamento) também duplica, mas pode ser **reagendamento legítimo** (novo agendamento = nova confirmação). Precisa de decisão do produto antes de alterar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Versão

* **Chores**
  * Ajustado o período de retenção de histórico para filtragem de mensagens SMS nas campanhas de puérperas, aumentando o intervalo de 1 para 300 dias em três agendamentos distintos. Esta alteração refina a janela de processamento para os ciclos de mensagens programadas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->