### PR TITLE
Staging/crm get history

### DIFF
--- a/pipelines/rj_crm__get_history_data/Dockerfile
+++ b/pipelines/rj_crm__get_history_data/Dockerfile
@@ -1,0 +1,12 @@
+FROM ghcr.io/prefeitura-rio/prefect_rj_iplanrio:latest
+
+LABEL org.opencontainers.image.source=https://github.com/prefeitura-rio/prefect_rj_iplanrio
+
+WORKDIR /opt/prefect/prefect_rj_iplanrio
+
+COPY ./pyproject.toml ./uv.lock /opt/prefect/prefect_rj_iplanrio/
+COPY ./src ./src/
+
+COPY ./pipelines/rj_crm__get_history_data ./pipelines/rj_crm__get_history_data/
+
+RUN uv sync --package rj_crm__get_history_data

--- a/pipelines/rj_crm__get_history_data/constants.py
+++ b/pipelines/rj_crm__get_history_data/constants.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+"""
+Constantes específicas para pipeline CRM Get History Data (SFMC)
+"""
+
+from enum import Enum
+
+
+class GetHistoryDataConstants(Enum):
+    """
+    Constantes para o pipeline de extração de Data Extensions históricas do SFMC
+    """
+
+    # Sufixo que identifica DEs históricas
+    DE_SUFFIX = "historico"
+
+    # REST API: máximo de registros por página
+    SFMC_MAX_PAGE_SIZE = 2500
+
+    # Duração estimada do token OAuth2 em segundos (~20 minutos)
+    TOKEN_CACHE_SECONDS = 1200

--- a/pipelines/rj_crm__get_history_data/flow.py
+++ b/pipelines/rj_crm__get_history_data/flow.py
@@ -7,7 +7,9 @@ from prefect import flow
 
 from pipelines.rj_crm__get_history_data.tasks import (
     authenticate_sfmc,
+    build_historico_dataframe,
     fetch_data_extension_data,
+    fetch_de_field_types,
     list_data_extensions_historico,
     process_historico_extraction,
 )
@@ -61,12 +63,19 @@ def rj_crm__get_history_data(
                 de_name=de["name"],
                 rest_uri=rest_uri,
             )
+            field_types = fetch_de_field_types(
+                access_token=access_token,
+                customer_key=de["external_key"],
+                de_name=de["name"],
+                soap_uri=soap_uri,
+            )
             extraction_results.append({
                 "de_name": de["name"],
                 "external_key": de["external_key"],
                 "status": "success",
                 "total_rows": len(rows),
-                "sample": rows[0] if rows else None,
+                "dados": rows,
+                "tipos": field_types,
             })
         except Exception as exc:
             print(f"Erro ao extrair DE '{de['name']}': {exc}")
@@ -75,8 +84,10 @@ def rj_crm__get_history_data(
                 "external_key": de["external_key"],
                 "status": "error",
                 "total_rows": 0,
+                "dados": [],
+                "tipos": [],
                 "error": str(exc),
             })
 
-    summary = process_historico_extraction(results=extraction_results)
-    return summary
+    process_historico_extraction(results=extraction_results)
+    build_historico_dataframe(results=extraction_results)

--- a/pipelines/rj_crm__get_history_data/flow.py
+++ b/pipelines/rj_crm__get_history_data/flow.py
@@ -28,8 +28,8 @@ def rj_crm__get_history_data(
         4. Loga resumo estruturado (totais, amostras, erros)
 
     Args:
-        rest_uri: URI REST do SFMC. Se não fornecido, usa env SFMC_REST_URI.
-        soap_uri: URI SOAP do SFMC. Se não fornecido, usa env SFMC_SOAP_URI.
+        rest_uri: URI REST do SFMC. Se não fornecido, usa env API_SFMC_REST_BASE_URL.
+        soap_uri: URI SOAP do SFMC. Se não fornecido, usa env API_SFMC_SOAP_BASE_URL.
     """
     rest_uri = rest_uri or os.getenv("API_SFMC_REST_BASE_URL", "")
     soap_uri = soap_uri or os.getenv("API_SFMC_SOAP_BASE_URL", "")

--- a/pipelines/rj_crm__get_history_data/flow.py
+++ b/pipelines/rj_crm__get_history_data/flow.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+
+import os
+from typing import Any, Dict, List, Optional
+
+from prefect import flow
+
+from pipelines.rj_crm__get_history_data.tasks import (
+    authenticate_sfmc,
+    fetch_data_extension_data,
+    list_data_extensions_historico,
+    process_historico_extraction,
+)
+
+
+@flow(log_prints=True)
+def rj_crm__get_history_data(
+    rest_uri: Optional[str] = None,
+    soap_uri: Optional[str] = None,
+):
+    """
+    Flow para extrair dados de todas as Data Extensions do SFMC com sufixo 'historico'.
+
+    Passos:
+        1. Autentica com SFMC via OAuth2 (client_credentials)
+        2. Lista DEs cujo nome termina em 'historico' via SOAP API
+        3. Para cada DE, extrai todos os registros via REST API com paginação
+        4. Loga resumo estruturado (totais, amostras, erros)
+
+    Args:
+        rest_uri: URI REST do SFMC. Se não fornecido, usa env SFMC_REST_URI.
+        soap_uri: URI SOAP do SFMC. Se não fornecido, usa env SFMC_SOAP_URI.
+    """
+    rest_uri = rest_uri or os.getenv("SFMC_REST_URI", "")
+    soap_uri = soap_uri or os.getenv("SFMC_SOAP_URI", "")
+
+    if not rest_uri:
+        raise ValueError("SFMC_REST_URI não definida. Passe via parâmetro ou variável de ambiente.")
+    if not soap_uri:
+        raise ValueError("SFMC_SOAP_URI não definida. Passe via parâmetro ou variável de ambiente.")
+
+    access_token = authenticate_sfmc()
+
+    data_extensions = list_data_extensions_historico(
+        access_token=access_token,
+        soap_uri=soap_uri,
+    )
+
+    if not data_extensions:
+        print("Nenhuma Data Extension com sufixo 'historico' encontrada. Flow finalizado.")
+        return
+
+    print(f"Processando {len(data_extensions)} DEs com sufixo 'historico'...")
+
+    extraction_results: List[Dict[str, Any]] = []
+    for de in data_extensions:
+        try:
+            rows = fetch_data_extension_data(
+                access_token=access_token,
+                external_key=de["external_key"],
+                de_name=de["name"],
+                rest_uri=rest_uri,
+            )
+            extraction_results.append({
+                "de_name": de["name"],
+                "external_key": de["external_key"],
+                "status": "success",
+                "total_rows": len(rows),
+                "sample": rows[0] if rows else None,
+            })
+        except Exception as exc:
+            print(f"Erro ao extrair DE '{de['name']}': {exc}")
+            extraction_results.append({
+                "de_name": de["name"],
+                "external_key": de["external_key"],
+                "status": "error",
+                "total_rows": 0,
+                "error": str(exc),
+            })
+
+    summary = process_historico_extraction(results=extraction_results)
+    return summary

--- a/pipelines/rj_crm__get_history_data/flow.py
+++ b/pipelines/rj_crm__get_history_data/flow.py
@@ -31,13 +31,13 @@ def rj_crm__get_history_data(
         rest_uri: URI REST do SFMC. Se não fornecido, usa env SFMC_REST_URI.
         soap_uri: URI SOAP do SFMC. Se não fornecido, usa env SFMC_SOAP_URI.
     """
-    rest_uri = rest_uri or os.getenv("SFMC_REST_URI", "")
-    soap_uri = soap_uri or os.getenv("SFMC_SOAP_URI", "")
+    rest_uri = rest_uri or os.getenv("API_SFMC_REST_BASE_URL", "")
+    soap_uri = soap_uri or os.getenv("API_SFMC_SOAP_BASE_URL", "")
 
     if not rest_uri:
-        raise ValueError("SFMC_REST_URI não definida. Passe via parâmetro ou variável de ambiente.")
+        raise ValueError("API_SFMC_REST_BASE_URL não definida. Passe via parâmetro ou variável de ambiente.")
     if not soap_uri:
-        raise ValueError("SFMC_SOAP_URI não definida. Passe via parâmetro ou variável de ambiente.")
+        raise ValueError("API_SFMC_SOAP_BASE_URL não definida. Passe via parâmetro ou variável de ambiente.")
 
     access_token = authenticate_sfmc()
 

--- a/pipelines/rj_crm__get_history_data/prefect.yaml
+++ b/pipelines/rj_crm__get_history_data/prefect.yaml
@@ -1,0 +1,53 @@
+name: rj_crm__get_history_data
+prefect-version: 3.4.3
+
+build:
+  - prefect.deployments.steps.run_shell_script:
+      id: get-commit-hash
+      script: git rev-parse --short HEAD
+      stream_output: false
+  - prefect_docker.deployments.steps.build_docker_image:
+      id: build-image
+      requires: prefect-docker>=0.6.5
+      image_name: ghcr.io/prefeitura-rio/prefect_rj_iplanrio/deployments
+      tag: "rj_crm__get_history_data-{{ get-commit-hash.stdout }}"
+      dockerfile: pipelines/rj_crm__get_history_data/Dockerfile
+
+push:
+  - prefect_docker.deployments.steps.push_docker_image:
+      requires: prefect-docker>=0.6.5
+      image_name: "{{ build-image.image_name }}"
+      tag: "{{ build-image.tag }}"
+
+pull:
+  - prefect.deployments.steps.set_working_directory:
+      directory: /opt/prefect/prefect_rj_iplanrio
+
+deployments:
+  - name: rj-crm--get-history-data--staging
+    version: "{{ build-image.tag }}"
+    entrypoint: pipelines/rj_crm__get_history_data/flow.py:rj_crm__get_history_data
+    work_pool:
+      name: default-pool
+      work_queue_name: default
+      job_variables:
+        image: "{{ build-image.image_name }}:{{ build-image.tag }}"
+        command: uv run --package rj_crm__get_history_data -- prefect flow-run execute
+        secretName: prefect-jobs-crm-registry-secrets-staging
+        image_pull_policy: Always
+
+  - name: rj-crm--get-history-data--prod
+    version: "{{ get-commit-hash.stdout }}"
+    entrypoint: pipelines/rj_crm__get_history_data/flow.py:rj_crm__get_history_data
+    work_pool:
+      name: default-pool
+      work_queue_name: default
+      job_variables:
+        image: "{{ build-image.image_name }}:{{ build-image.tag }}"
+        command: uv run --package rj_crm__get_history_data -- prefect flow-run execute
+        secretName: prefect-jobs-crm-registry-secrets
+        image_pull_policy: Always
+    schedules:
+      - cron: "0 6 * * *"
+        timezone: America/Sao_Paulo
+        slug: get_history_data_daily

--- a/pipelines/rj_crm__get_history_data/pyproject.toml
+++ b/pipelines/rj_crm__get_history_data/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "rj_crm__get_history_data"
+version = "0.1.0"
+description = "Pipeline CRM para extração de Data Extensions históricas do Salesforce Marketing Cloud"
+dependencies = [
+    "prefect_rj_iplanrio",
+    "prefect==3.4.9",
+    "prefect-docker>=0.6.5",
+    "requests>=2.31.0",
+    "python-dotenv==1.0.1",
+    "prefeitura-rio[actions] @ git+https://github.com/prefeitura-rio/prefeitura-rio@54593ddff444158b0ecbab5514c5cde4d44012c0",
+]
+
+[tool.uv.sources]
+prefect_rj_iplanrio = { workspace = true }

--- a/pipelines/rj_crm__get_history_data/tasks.py
+++ b/pipelines/rj_crm__get_history_data/tasks.py
@@ -223,6 +223,116 @@ def fetch_data_extension_data(
 
 
 @task
+def fetch_de_field_types(
+    access_token: str,
+    customer_key: str,
+    de_name: str,
+    soap_uri: str,
+) -> List[Dict[str, str]]:
+    """
+    Retorna o schema (nome + tipo + pk) de uma Data Extension via SOAP API.
+    Usa ObjectType=DataExtensionField filtrado por DataExtension.CustomerKey.
+    """
+    endpoint = f"{soap_uri.rstrip('/')}/Service.asmx"
+    headers = {
+        "Content-Type": "text/xml; charset=utf-8",
+        "SOAPAction": "Retrieve",
+    }
+
+    envelope = f"""<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope
+    xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns="http://exacttarget.com/wsdl/partnerAPI">
+    <soapenv:Header>
+        <fueloauth xmlns="http://exacttarget.com/wsdl/partnerAPI">{access_token}</fueloauth>
+    </soapenv:Header>
+    <soapenv:Body>
+        <RetrieveRequestMsg>
+            <RetrieveRequest>
+                <ObjectType>DataExtensionField</ObjectType>
+                <Properties>Name</Properties>
+                <Properties>FieldType</Properties>
+                <Properties>IsRequired</Properties>
+                <Properties>IsPrimaryKey</Properties>
+                <Filter xsi:type="SimpleFilterPart">
+                    <Property>DataExtension.CustomerKey</Property>
+                    <SimpleOperator>equals</SimpleOperator>
+                    <Value>{customer_key}</Value>
+                </Filter>
+            </RetrieveRequest>
+        </RetrieveRequestMsg>
+    </soapenv:Body>
+</soapenv:Envelope>""".encode("utf-8")
+
+    response = requests.post(endpoint, data=envelope, headers=headers, timeout=60)
+    response.raise_for_status()
+
+    root = ET.fromstring(response.text)
+    body = root.find(f"{{{_SOAP_NS}}}Body")
+    response_msg = body.find(f"{{{_ET_NS}}}RetrieveResponseMsg")
+
+    fields = []
+    for result in response_msg.findall(f"{{{_ET_NS}}}Results"):
+        fields.append({
+            "name": result.findtext(f"{{{_ET_NS}}}Name", default=""),
+            "type": result.findtext(f"{{{_ET_NS}}}FieldType", default=""),
+            "is_pk": result.findtext(f"{{{_ET_NS}}}IsPrimaryKey", default="false"),
+        })
+
+    log(f"  [{de_name}] Schema: {len(fields)} campos | "
+        f"phone={next((f['name'] for f in fields if f['type'].lower() == 'phone'), None)} | "
+        f"pk={next((f['name'] for f in fields if f['is_pk'].lower() == 'true'), None)}")
+    return fields
+
+
+@task
+def build_historico_dataframe(results: List[Dict[str, Any]]) -> None:
+    """
+    Constrói e loga um DataFrame com uma linha por registro de cada DE.
+
+    Colunas:
+        de_name  - nome da Data Extension
+        telefone - valor da coluna de tipo Phone
+        pk_de    - valor da coluna que é Primary Key
+        data     - todos os campos do registro em JSON
+    """
+    import json
+
+    import pandas as pd
+
+    rows = []
+    for result in results:
+        if result.get("status") != "success":
+            continue
+
+        de_name = result["de_name"]
+        dados = result.get("dados", [])
+        field_types = result.get("tipos", [])
+
+        phone_col = next((f["name"] for f in field_types if f["type"].lower() == "phone"), None)
+        pk_col = next((f["name"] for f in field_types if f["is_pk"].lower() == "true"), None)
+
+        for item in dados:
+            keys = item.get("keys", item)
+            rows.append({
+                "de_name": de_name,
+                "telefone": keys.get(phone_col) if phone_col else None,
+                "pk_de": keys.get(pk_col) if pk_col else None,
+                "data": json.dumps(keys, ensure_ascii=False),
+            })
+
+    df = pd.DataFrame(rows, columns=["de_name", "telefone", "pk_de", "data"])
+
+    log("=" * 60)
+    log("DATAFRAME HISTORICO SFMC")
+    log(f"Shape: {df.shape[0]} linhas x {df.shape[1]} colunas")
+    log("=" * 60)
+    log(f"\n{df.to_string()}")
+
+
+@task
 def process_historico_extraction(results: List[Dict[str, Any]]) -> Dict[str, Any]:
     """
     Agrega resultados da extração e loga resumo estruturado.

--- a/pipelines/rj_crm__get_history_data/tasks.py
+++ b/pipelines/rj_crm__get_history_data/tasks.py
@@ -24,17 +24,15 @@ def authenticate_sfmc() -> str:
     Autentica com Salesforce Marketing Cloud via OAuth2 e retorna o access token.
     POST {SFMC_AUTH_URI}/v2/token
     """
-    auth_uri = os.getenv("SFMC_AUTH_URI", "")
-    client_id = os.getenv("SFMC_CLIENT_ID", "")
-    client_secret = os.getenv("SFMC_CLIENT_SECRET", "")
-    account_id = os.getenv("SFMC_ACCOUNT_ID", "")
+    auth_uri = os.getenv("API_SFMC_AUTH_URL", "")
+    client_id = os.getenv("API_SFMC_CLIENT_ID", "")
+    client_secret = os.getenv("API_SFMC_CLIENT_SECRET", "")
 
     missing = [
         name for name, val in {
-            "SFMC_AUTH_URI": auth_uri,
-            "SFMC_CLIENT_ID": client_id,
-            "SFMC_CLIENT_SECRET": client_secret,
-            "SFMC_ACCOUNT_ID": account_id,
+            "API_SFMC_AUTH_URL": auth_uri,
+            "API_SFMC_CLIENT_ID": client_id,
+            "API_SFMC_CLIENT_SECRET": client_secret,
         }.items()
         if not val
     ]
@@ -46,7 +44,6 @@ def authenticate_sfmc() -> str:
         "grant_type": "client_credentials",
         "client_id": client_id,
         "client_secret": client_secret,
-        "account_id": account_id,
     }
 
     log(f"Autenticando no SFMC via {url}")

--- a/pipelines/rj_crm__get_history_data/tasks.py
+++ b/pipelines/rj_crm__get_history_data/tasks.py
@@ -1,0 +1,268 @@
+# -*- coding: utf-8 -*-
+"""
+Tasks para pipeline CRM Get History Data (SFMC)
+Extrai dados de Data Extensions com sufixo 'historico' do Salesforce Marketing Cloud
+"""
+
+import os
+import xml.etree.ElementTree as ET
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+from iplanrio.pipelines_utils.logging import log
+from prefect import task
+
+from pipelines.rj_crm__get_history_data.constants import GetHistoryDataConstants
+
+_SOAP_NS = "http://schemas.xmlsoap.org/soap/envelope/"
+_ET_NS = "http://exacttarget.com/wsdl/partnerAPI"
+
+
+@task
+def authenticate_sfmc() -> str:
+    """
+    Autentica com Salesforce Marketing Cloud via OAuth2 e retorna o access token.
+    POST {SFMC_AUTH_URI}/v2/token
+    """
+    auth_uri = os.getenv("SFMC_AUTH_URI", "")
+    client_id = os.getenv("SFMC_CLIENT_ID", "")
+    client_secret = os.getenv("SFMC_CLIENT_SECRET", "")
+    account_id = os.getenv("SFMC_ACCOUNT_ID", "")
+
+    missing = [
+        name for name, val in {
+            "SFMC_AUTH_URI": auth_uri,
+            "SFMC_CLIENT_ID": client_id,
+            "SFMC_CLIENT_SECRET": client_secret,
+            "SFMC_ACCOUNT_ID": account_id,
+        }.items()
+        if not val
+    ]
+    if missing:
+        raise ValueError(f"Variáveis de ambiente SFMC ausentes: {missing}")
+
+    url = f"{auth_uri.rstrip('/')}/v2/token"
+    payload = {
+        "grant_type": "client_credentials",
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "account_id": account_id,
+    }
+
+    log(f"Autenticando no SFMC via {url}")
+    response = requests.post(url, json=payload, timeout=30)
+    response.raise_for_status()
+
+    data = response.json()
+    access_token = data.get("access_token")
+    if not access_token:
+        raise ValueError(f"access_token não encontrado na resposta SFMC: {list(data.keys())}")
+
+    expires_in = data.get("expires_in", GetHistoryDataConstants.TOKEN_CACHE_SECONDS.value)
+    log(f"Autenticação SFMC bem-sucedida. Token válido por {expires_in}s")
+    return access_token
+
+
+def _build_soap_envelope(access_token: str, continue_request_id: Optional[str] = None) -> bytes:
+    """Monta o envelope SOAP para listagem de DataExtensions."""
+    if continue_request_id:
+        body_inner = f"""
+        <RetrieveRequestMsg>
+            <RetrieveRequest>
+                <ContinueRequest>{continue_request_id}</ContinueRequest>
+            </RetrieveRequest>
+        </RetrieveRequestMsg>
+        """
+    else:
+        body_inner = """
+        <RetrieveRequestMsg>
+            <RetrieveRequest>
+                <ObjectType>DataExtension</ObjectType>
+                <Properties>Name</Properties>
+                <Properties>CustomerKey</Properties>
+                <Properties>ObjectID</Properties>
+            </RetrieveRequest>
+        </RetrieveRequestMsg>
+        """
+
+    envelope = f"""<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope
+    xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns="http://exacttarget.com/wsdl/partnerAPI">
+    <soapenv:Header>
+        <fueloauth xmlns="http://exacttarget.com/wsdl/partnerAPI">{access_token}</fueloauth>
+    </soapenv:Header>
+    <soapenv:Body>
+        {body_inner}
+    </soapenv:Body>
+</soapenv:Envelope>"""
+    return envelope.encode("utf-8")
+
+
+def _parse_soap_response(xml_text: str) -> Tuple[str, str, List[Dict[str, str]]]:
+    """
+    Parseia a resposta SOAP de listagem de DataExtensions.
+    Retorna (overall_status, request_id, lista de DEs)
+    """
+    root = ET.fromstring(xml_text)
+    body = root.find(f"{{{_SOAP_NS}}}Body")
+    response_msg = body.find(f"{{{_ET_NS}}}RetrieveResponseMsg")
+
+    overall_status = response_msg.findtext(f"{{{_ET_NS}}}OverallStatus", default="")
+    request_id = response_msg.findtext(f"{{{_ET_NS}}}RequestID", default="")
+
+    results = []
+    for result in response_msg.findall(f"{{{_ET_NS}}}Results"):
+        name = result.findtext(f"{{{_ET_NS}}}Name", default="")
+        customer_key = result.findtext(f"{{{_ET_NS}}}CustomerKey", default="")
+        object_id = result.findtext(f"{{{_ET_NS}}}ObjectID", default="")
+        results.append({
+            "name": name,
+            "external_key": customer_key,
+            "object_id": object_id,
+        })
+
+    return overall_status, request_id, results
+
+
+@task
+def list_data_extensions_historico(access_token: str, soap_uri: str) -> List[Dict[str, str]]:
+    """
+    Lista todas as Data Extensions com nome terminando em 'historico' via SOAP API.
+    Trata paginação SOAP via status MoreDataAvailable.
+
+    Args:
+        access_token: Token OAuth2 do SFMC
+        soap_uri: URI base do endpoint SOAP (ex: https://mcXXX.soap.marketingcloudapis.com)
+
+    Returns:
+        Lista de dicts com {name, external_key, object_id}
+    """
+    endpoint = f"{soap_uri.rstrip('/')}/Service.asmx"
+    headers = {
+        "Content-Type": "text/xml; charset=utf-8",
+        "SOAPAction": "Retrieve",
+    }
+
+    all_des: List[Dict[str, str]] = []
+    continue_request_id: Optional[str] = None
+    page = 0
+
+    while True:
+        log(f"Buscando DataExtensions - página SOAP {page}")
+        envelope = _build_soap_envelope(access_token, continue_request_id)
+        response = requests.post(endpoint, data=envelope, headers=headers, timeout=60)
+        response.raise_for_status()
+
+        overall_status, request_id, results = _parse_soap_response(response.text)
+        log(f"Página SOAP {page}: status={overall_status}, DEs retornadas={len(results)}")
+        all_des.extend(results)
+
+        if overall_status == "MoreDataAvailable":
+            continue_request_id = request_id
+            page += 1
+        elif overall_status in ("OK", ""):
+            break
+        else:
+            raise RuntimeError(f"SOAP API retornou status inesperado: {overall_status}")
+
+    suffix = GetHistoryDataConstants.DE_SUFFIX.value
+    historico_des = [de for de in all_des if de["name"].lower().endswith(suffix)]
+
+    log(f"Total de DEs encontradas: {len(all_des)}, com sufixo '{suffix}': {len(historico_des)}")
+    for de in historico_des:
+        log(f"  -> {de['name']} (key={de['external_key']}, id={de['object_id']})")
+
+    return historico_des
+
+
+@task
+def fetch_data_extension_data(
+    access_token: str,
+    external_key: str,
+    de_name: str,
+    rest_uri: str,
+) -> List[Dict[str, Any]]:
+    """
+    Extrai todos os registros de uma Data Extension via REST API com paginação.
+    GET {rest_uri}/data/v1/customobjectdata/key/{external_key}/rowset?$page={page}
+
+    Args:
+        access_token: Token OAuth2 do SFMC
+        external_key: CustomerKey da DE
+        de_name: Nome da DE (para logging)
+        rest_uri: URI base do endpoint REST (ex: https://mcXXX.rest.marketingcloudapis.com)
+
+    Returns:
+        Lista de dicts com todos os registros da DE
+    """
+    headers = {"Authorization": f"Bearer {access_token}"}
+    base_url = f"{rest_uri.rstrip('/')}/data/v1/customobjectdata/key/{external_key}/rowset"
+
+    all_rows: List[Dict[str, Any]] = []
+    page = 1
+
+    log(f"Iniciando extração de '{de_name}' (key={external_key})")
+
+    while True:
+        response = requests.get(base_url, headers=headers, params={"$page": page}, timeout=60)
+        response.raise_for_status()
+
+        data = response.json()
+        page_count = data.get("pageCount", 1)
+        items = data.get("items", [])
+
+        log(f"  [{de_name}] Página {page}/{page_count}: {len(items)} registros")
+        all_rows.extend(items)
+
+        if page >= page_count:
+            break
+        page += 1
+
+    log(f"  [{de_name}] Extração concluída: {len(all_rows)} registros no total")
+    return all_rows
+
+
+@task
+def process_historico_extraction(results: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Agrega resultados da extração e loga resumo estruturado.
+
+    Args:
+        results: Lista de dicts com resultado por DE
+                 (campos: de_name, external_key, status, total_rows, sample, error)
+
+    Returns:
+        Dict com metadados: des_sucesso, des_erro, total_registros, detalhes
+    """
+    des_sucesso = [r for r in results if r.get("status") == "success"]
+    des_erro = [r for r in results if r.get("status") == "error"]
+    total_registros = sum(r.get("total_rows", 0) for r in des_sucesso)
+
+    log("=" * 60)
+    log("RESUMO DA EXTRACAO DE HISTORICOS SFMC")
+    log("=" * 60)
+    log(f"DEs processadas com sucesso : {len(des_sucesso)}")
+    log(f"DEs com erro                : {len(des_erro)}")
+    log(f"Total de registros extraidos: {total_registros}")
+
+    if des_sucesso:
+        log("\nAmostras (1 linha por DE):")
+        for r in des_sucesso:
+            log(f"  [{r['de_name']}] total={r['total_rows']} | amostra={r.get('sample')}")
+
+    if des_erro:
+        log("\nErros detalhados:")
+        for r in des_erro:
+            log(f"  [{r['de_name']}] ERRO: {r.get('error')}", level="error")
+
+    log("=" * 60)
+
+    return {
+        "des_sucesso": len(des_sucesso),
+        "des_erro": len(des_erro),
+        "total_registros": total_registros,
+        "detalhes": results,
+    }

--- a/pipelines/rj_crm__salesforce_api/Dockerfile
+++ b/pipelines/rj_crm__salesforce_api/Dockerfile
@@ -1,0 +1,19 @@
+FROM ghcr.io/prefeitura-rio/prefect_rj_iplanrio:latest
+
+LABEL org.opencontainers.image.source=https://github.com/prefeitura-rio/prefect_rj_iplanrio
+
+# Install GEOS library and build dependencies for spatial operations (required by Shapely)
+RUN apt-get update && apt-get install -y \
+    libgeos-dev \
+    libgeos-c1v5 \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/prefect/prefect_rj_iplanrio
+
+COPY ./pyproject.toml ./uv.lock /opt/prefect/prefect_rj_iplanrio/
+COPY ./src ./src/
+
+COPY ./pipelines/rj_crm__disparo_template ./pipelines/rj_crm__disparo_template/
+
+RUN uv sync --package rj_crm__disparo_template

--- a/pipelines/rj_crm__salesforce_api/Dockerfile
+++ b/pipelines/rj_crm__salesforce_api/Dockerfile
@@ -2,18 +2,13 @@ FROM ghcr.io/prefeitura-rio/prefect_rj_iplanrio:latest
 
 LABEL org.opencontainers.image.source=https://github.com/prefeitura-rio/prefect_rj_iplanrio
 
-# Install GEOS library and build dependencies for spatial operations (required by Shapely)
-RUN apt-get update && apt-get install -y \
-    libgeos-dev \
-    libgeos-c1v5 \
-    build-essential \
-    && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /opt/prefect/prefect_rj_iplanrio
 
 COPY ./pyproject.toml ./uv.lock /opt/prefect/prefect_rj_iplanrio/
 COPY ./src ./src/
 
+# A pipeline rj_crm__salesforce_api importa create_date_partitions de rj_crm__disparo_template
 COPY ./pipelines/rj_crm__disparo_template ./pipelines/rj_crm__disparo_template/
+COPY ./pipelines/rj_crm__salesforce_api ./pipelines/rj_crm__salesforce_api/
 
-RUN uv sync --package rj_crm__disparo_template
+RUN uv sync --package rj_crm__salesforce_api

--- a/pipelines/rj_crm__salesforce_api/constants.py
+++ b/pipelines/rj_crm__salesforce_api/constants.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""
+Constantes específicas para pipeline de template
+"""
+
+from enum import Enum
+
+
+class TemplateConstants(Enum):
+    """
+    Constantes para o pipeline de disparo de template
+    """
+
+    # HSM Template ID para mensagens
+    ID_HSM = 101
+
+    # Nome da campanha
+    CAMPAIGN_NAME = "template"
+
+    # Cost Center ID
+    COST_CENTER_ID = 71
+
+    # Billing Project ID
+    BILLING_PROJECT_ID = "rj-crm-registry"
+
+    # Query processor name
+    QUERY_PROCESSOR_NAME = ""
+
+    # Configurações de dataset
+    DATASET_ID = "brutos_wetalkie"
+    TABLE_ID = "disparos_efetuados"
+    DUMP_MODE = "append"
+    CHUNK_SIZE = 1000
+
+    # Query principal do CadÚnico
+    QUERY = r"""
+        SELECT
+            TO_JSON_STRING(STRUCT(
+                REGEXP_REPLACE(telefone, r'[^\d]', '') as celular_disparo,
+                STRUCT(
+                    primeiro_nome as NOME,
+                    FORMAT_DATETIME('%d/%m/%Y', DATETIME(data_hora)) as DATA,
+                    FORMAT_DATETIME('%H:%M', DATETIME(data_hora)) as HORA,
+                    unidade_nome as LOCAL,
+                    CONCAT(unidade_endereco, ' - ', unidade_bairro) as ENDERECO
+                ) as vars,
+                cpf as externalId
+            )) as destination_data
+        FROM `rj-smas.brutos_data_metrica_staging.agendamentos_cadunico`
+        WHERE
+            DATE(data_hora) = DATE_ADD(
+            CURRENT_DATE("America/Sao_Paulo"),
+            INTERVAL {days_ahead} DAY)
+            AND telefone NOT IN (
+                SELECT contato_telefone
+                FROM `rj-crm-registry.crm_whatsapp.telefone_sem_whatsapp`
+                WHERE data_atualizacao > DATE_SUB(CURRENT_DATE(), INTERVAL 1 YEAR)
+            )
+            AND telefone IS NOT NULL
+            AND LENGTH(REGEXP_REPLACE(telefone, r'[^\d]', '')) >= 10
+            AND telefone NOT IN (
+                SELECT contato_telefone
+                FROM `rj-crm-registry-dev.patricia__crm_whatsapp.telefone_disparado`
+                WHERE id_hsm = '{hsm_id}'
+                    AND data_particao >= DATE_SUB(CURRENT_DATE(), INTERVAL 15 DAY)
+            )
+        ORDER BY data_hora
+    """

--- a/pipelines/rj_crm__salesforce_api/constants.py
+++ b/pipelines/rj_crm__salesforce_api/constants.py
@@ -1,68 +1,30 @@
 # -*- coding: utf-8 -*-
 """
-Constantes específicas para pipeline de template
+Constantes para a pipeline de ingestão de dados via Salesforce Marketing Cloud REST API.
 """
 
 from enum import Enum
 
 
-class TemplateConstants(Enum):
+class APIConstants(Enum):
     """
-    Constantes para o pipeline de disparo de template
+    Constantes para o flow genérico de ingestão de rotas GET da Salesforce Marketing Cloud REST API.
     """
 
-    # HSM Template ID para mensagens
-    ID_HSM = 101
+    # Dataset padrão no BigQuery
+    DATASET_ID = "brutos_salesforce"
 
-    # Nome da campanha
-    CAMPAIGN_NAME = "template"
-
-    # Cost Center ID
-    COST_CENTER_ID = 71
-
-    # Billing Project ID
-    BILLING_PROJECT_ID = "rj-crm-registry"
-
-    # Query processor name
-    QUERY_PROCESSOR_NAME = ""
-
-    # Configurações de dataset
-    DATASET_ID = "brutos_wetalkie"
-    TABLE_ID = "disparos_efetuados"
+    # Modo de ingestão padrão
     DUMP_MODE = "append"
-    CHUNK_SIZE = 1000
 
-    # Query principal do CadÚnico
-    QUERY = r"""
-        SELECT
-            TO_JSON_STRING(STRUCT(
-                REGEXP_REPLACE(telefone, r'[^\d]', '') as celular_disparo,
-                STRUCT(
-                    primeiro_nome as NOME,
-                    FORMAT_DATETIME('%d/%m/%Y', DATETIME(data_hora)) as DATA,
-                    FORMAT_DATETIME('%H:%M', DATETIME(data_hora)) as HORA,
-                    unidade_nome as LOCAL,
-                    CONCAT(unidade_endereco, ' - ', unidade_bairro) as ENDERECO
-                ) as vars,
-                cpf as externalId
-            )) as destination_data
-        FROM `rj-smas.brutos_data_metrica_staging.agendamentos_cadunico`
-        WHERE
-            DATE(data_hora) = DATE_ADD(
-            CURRENT_DATE("America/Sao_Paulo"),
-            INTERVAL {days_ahead} DAY)
-            AND telefone NOT IN (
-                SELECT contato_telefone
-                FROM `rj-crm-registry.crm_whatsapp.telefone_sem_whatsapp`
-                WHERE data_atualizacao > DATE_SUB(CURRENT_DATE(), INTERVAL 1 YEAR)
-            )
-            AND telefone IS NOT NULL
-            AND LENGTH(REGEXP_REPLACE(telefone, r'[^\d]', '')) >= 10
-            AND telefone NOT IN (
-                SELECT contato_telefone
-                FROM `rj-crm-registry-dev.patricia__crm_whatsapp.telefone_disparado`
-                WHERE id_hsm = '{hsm_id}'
-                    AND data_particao >= DATE_SUB(CURRENT_DATE(), INTERVAL 15 DAY)
-            )
-        ORDER BY data_hora
-    """
+    # Path padrão no Infisical para credenciais da Salesforce Marketing Cloud
+    INFISICAL_SECRET_PATH = "/salesforce_marketing_cloud"
+
+    # Pasta temporária para armazenar os dados antes do upload
+    ROOT_FOLDER = "/tmp/data_salesforce_api"
+
+    # Formato de arquivo para particionamento
+    FILE_FORMAT = "csv"
+
+    # Coluna usada para particionamento por data
+    PARTITION_COLUMN = "data_particao"

--- a/pipelines/rj_crm__salesforce_api/flow.py
+++ b/pipelines/rj_crm__salesforce_api/flow.py
@@ -1,700 +1,97 @@
 # -*- coding: utf-8 -*-
-# flake8: noqa:E501
-# pylint: disable='line-too-long'
+"""
+Flow genérico para ingestão de dados via rotas GET da Salesforce Marketing Cloud REST API.
+
+Cada scheduler no prefect.yaml define uma rota e um table_id distintos.
+Os dados são salvos no BigQuery no formato:
+  - dataset_id (padrão: brutos_salesforce)
+  - table_id   (definido por parâmetro)
+  - Colunas: data (JSON string), data_particao (YYYY-MM-DD)
 
 """
-Flow to dispatch templated messages via Wetalkie API
-"""
+
 import os
-import time
-from math import ceil
-import pendulum
 
-from iplanrio.pipelines_utils.bd import create_table_and_upload_to_gcs_task  # pylint: disable=E0611, E0401
-from iplanrio.pipelines_utils.env import getenv_or_action, inject_bd_credentials_task  # pylint: disable=E0611, E0401
-from iplanrio.pipelines_utils.prefect import rename_current_flow_run_task  # pylint: disable=E0611, E0401
-from prefect import flow  # pylint: disable=E0611, E0401
-from prefect.client.schemas.objects import Flow, FlowRun, State  # pylint: disable=E0611, E0401
+from iplanrio.pipelines_utils.bd import create_table_and_upload_to_gcs_task
+from iplanrio.pipelines_utils.env import inject_bd_credentials_task
+from iplanrio.pipelines_utils.prefect import rename_current_flow_run_task
+from prefect import flow
 
-from pipelines.rj_crm__disparo_template.constants import TemplateConstants  # pylint: disable=E0611, E0401
-# pylint: disable=E0611, E0401
-from pipelines.rj_crm__disparo_template.utils.discord import (
-    send_dispatch_no_destinations_found,
-    # send_retry_dispatch_result_notification,
-    send_dispatch_success_notification,
-    send_discord_notification,
-)
-# pylint: disable=E0611, E0401
-from pipelines.rj_crm__disparo_template.utils.dispatch import (
-    add_contacts_to_whitelist,
-    check_api_status,
-    check_flow_status,
-    create_dispatch_dfr,
-    create_dispatch_payload,
-    create_log_df,
-    dispatch,
-    filter_already_dispatched_phones_or_cpfs,
-    format_query,
-    get_already_dispatched_data,
-    get_destinations,
-    get_failed_cpfs,
-    get_failed_phones,
-    get_retry_destinations,
-    remove_contacts_from_whitelist,
-    remove_duplicate_cpfs,
-    remove_duplicate_phones,
-    remove_failed_phones,
-    save_csv_for_sftp,
-    send_to_sftp,
-)
-# pylint: disable=E0611, E0401
-from pipelines.rj_crm__disparo_template.utils.validators import validate_sf_dataframe
-# pylint: disable=E0611, E0401
-from pipelines.rj_crm__disparo_template.utils.tasks import (
-    access_api,
-    create_date_partitions,
-    task_download_data_from_bigquery,
-)
+from pipelines.rj_crm__salesforce_api.constants import APIConstants
+from pipelines.rj_crm__salesforce_api.tasks import build_dataframe, fetch_sfmc_route
+from pipelines.rj_crm__disparo_template.utils.tasks import create_date_partitions
 
 
-def send_discord_notification_on_failure(flow: Flow, flow_run: FlowRun, state: State):
-    """
-    Sends a Discord notification when a flow run fails.
-    """
-    # Only send notification if flow_environment is production
-    flow_environment = flow_run.parameters.get("flow_environment", "staging")
-    if flow_environment != "production":
-        print(f"Flow failed in {flow_environment} environment. Skipping Discord notification.")
-        return
-
-    webhook_url = os.getenv("DISCORD_WEBHOOK_URL_ERRORS")
-    if not webhook_url:
-        print("DISCORD_WEBHOOK_URL_ERRORS environment variable not set on Infisical. Cannot send notification.")
-        return
-
-    campaign_name = flow_run.parameters.get("campaign_name", "N/A")
-    id_hsm = flow_run.parameters.get("id_hsm", "N/A")
-    cost_center_id = flow_run.parameters.get("cost_center_id", "N/A")
-
-    message = f"""
-    Prefect flow run failed in PRODUCTION! 🚨
-    📋 **Campanha:** {campaign_name}
-    🆔 **Template ID:** {id_hsm}
-    💰 **Centro de Custo:** {cost_center_id}
-    ⚠️ **Mensagem:** {state.message}
-    """
-    send_discord_notification(webhook_url, message)
-
-# force deploy
-@flow(log_prints=True, on_failure=[send_discord_notification_on_failure])
-def rj_crm__disparo_template_sf(
-    # Parâmetros opcionais para override manual na UI.
-    id_hsm: int | None = None,
-    campaign_name: str | None = None,
-    cost_center_id: int | None = None,
+@flow(log_prints=True)
+def rj_crm__salesforce_api(
+    route: str,
+    table_id: str,
     dataset_id: str | None = None,
-    table_id: str | None = None,
     dump_mode: str | None = None,
-    test_mode: bool | None = True,
-    query: str | None = None,
-    query_processor_name: str | None = None,
-    query_replacements: dict | None = None,
-    filter_dispatched_phones_or_cpfs: str | None = "cpf",
-    filter_duplicated_phones: bool = True,
-    filter_duplicated_cpfs: bool = True,
-    filter_failed_phones: bool = False,
-    sleep_minutes: int | None = 5,
-    max_dispatch_retries: int = 0,
-    infisical_secret_path: str = "/crm_disparo_template",
-    data_extension_filename: str | None = None,
-    whitelist_percentage: int = 0,
-    whitelist_environment: str = "production",
-    flow_environment: str = "staging",
-    force_add_on_whitelist_group: bool = False,
-    whitelist_replace_contacts: bool = False,
+    route_params: dict | None = None,
+    query_params: dict | None = None,
+    infisical_secret_path: str | None = None,
 ):
     """
-    Orchestrates the dispatch of templated messages via Salesforce SFTP.
+    Flow genérico para ingestão de qualquer rota GET da Salesforce Marketing Cloud REST API.
 
-    Fetches destinations from BigQuery, applies filters, generates a CSV with
-    a 'telefone' plus all query fields, saves it to
-    disk, and uploads it to the configured SFTP server.
-    Dispatch results are also logged to BigQuery.
-
-    SFTP credentials (sf_sftp_host, sf_sftp_user, sf_sftp_password) must be available
-    as environment variables injected from Infisical at infisical_secret_path.
+    Os dados retornados pela API são armazenados no BigQuery como uma tabela com
+    duas colunas: `data` (JSON string com o conteúdo do registro) e
+    `data_particao` (data de execução, usada para particionamento).
 
     Args:
-        id_hsm (int, optional): The ID of the HSM template.
-        campaign_name (str, optional): The name of the dispatch campaign.
-        cost_center_id (int, optional): The ID of the cost center.
-        chunk_size (int, optional): Kept for interface compatibility; not used for SFTP batching.
-        dataset_id (str, optional): BigQuery dataset ID for dispatch logs.
-        table_id (str, optional): BigQuery table ID for dispatch logs.
-        dump_mode (str, optional): BigQuery dump mode (e.g., "append").
-        test_mode (bool, optional): If True, runs in test mode. Defaults to True.
-        query (str, optional): SQL query to retrieve destinations.
-        query_processor_name (str, optional): Name of the query processor.
-        query_replacements (dict, optional): Replacements for query placeholders.
-        filter_dispatched_phones_or_cpfs (str, optional): None, "cpf" or "phone_number". Defaults to "cpf".
-        filter_duplicated_phones (bool, optional): Remove duplicate phones. Defaults to True.
-        filter_duplicated_cpfs (bool, optional): Remove duplicate CPFs. Defaults to True.
-        filter_failed_phones (bool, optional): Remove phones that failed in last dispatch. Defaults to False.
-        sleep_minutes (int, optional): Minutes to sleep before dispatch. Defaults to 5.
-        max_dispatch_retries (int): Maximum retry attempts with alternative phones. Defaults to 0.
-        infisical_secret_path (str, optional): Infisical path for SFTP credentials. Defaults to "/sftp".
-        sftp_remote_path (str, optional): Remote directory on the SFTP server. Defaults to "/".
-        whitelist_percentage (int, optional): Percentage of contacts to whitelist. Defaults to 0.
-        whitelist_environment (str, optional): Whitelist environment. Defaults to "production".
-        flow_environment (str, optional): Flow environment ("staging" or "production"). Defaults to "staging".
-        force_add_on_whitelist_group (bool, optional): Force add to whitelist group. Defaults to False.
-        whitelist_replace_contacts (bool, optional): Remove contacts before adding to whitelist. Defaults to False.
+        route: Rota relativa da API SFMC. Pode conter placeholders {chave}.
+               Ex: "/asset/v1/content/assets/{assetId}"
+        table_id: Nome da tabela de destino no BigQuery.
+        dataset_id: Dataset de destino. Padrão: "brutos_salesforce".
+        dump_mode: Modo de ingestão BigQuery ("append" ou "overwrite"). Padrão: "append".
+        route_params: Dicionário para substituição de placeholders na rota.
+                      Ex: {"assetId": "12345"}
+        query_params: Query string parameters adicionais.
+                      Ex: {"$page": 1, "$pageSize": 50}
+        infisical_secret_path: Path no Infisical para as credenciais da SFMC.
+                               Padrão: "/salesforce_marketing_cloud".
     """
+    dataset_id = dataset_id or APIConstants.DATASET_ID.value
+    dump_mode = dump_mode or APIConstants.DUMP_MODE.value
+    infisical_secret_path = infisical_secret_path or APIConstants.INFISICAL_SECRET_PATH.value
+    root_folder = APIConstants.ROOT_FOLDER.value
+    file_format = APIConstants.FILE_FORMAT.value
+    partition_column = APIConstants.PARTITION_COLUMN.value
 
-    dataset_id = dataset_id or TemplateConstants.DATASET_ID.value
-    table_id = table_id or TemplateConstants.TABLE_ID.value
-    dump_mode = dump_mode or TemplateConstants.DUMP_MODE.value
-    id_hsm = id_hsm or TemplateConstants.ID_HSM.value
-    campaign_name = campaign_name or TemplateConstants.CAMPAIGN_NAME.value
-    cost_center_id = cost_center_id or TemplateConstants.COST_CENTER_ID.value
-    query = query or TemplateConstants.QUERY.value
-    query_processor_name = query_processor_name or TemplateConstants.QUERY_PROCESSOR_NAME.value
-    billing_project_id = TemplateConstants.BILLING_PROJECT_ID.value
+    rename_current_flow_run_task(new_name=f"sfmc_api__{table_id}__{dataset_id}")
+    inject_bd_credentials_task(environment="prod")
 
-    rename_flow_run = rename_current_flow_run_task(new_name=f"{table_id}_{dataset_id}")  # pylint: disable=unused-variable
-    crd = inject_bd_credentials_task(environment="prod")  # noqa  # pylint: disable=unused-variable
-
-    flow_status = check_flow_status(
-        flow_environment=flow_environment,
-        billing_project_id=billing_project_id,
-        bucket_name=billing_project_id,
-        id_hsm=id_hsm,
-        campaign_name=campaign_name,
-    )
-    if flow_status is None:
-        print("Ending flow due to inactive status.")
-        return
-
-    if test_mode:
-        campaign_name = "teste-" + campaign_name
-        print("⚠️  MODO DE TESTE ATIVADO - Disparos para números de teste apenas")
-
-    if query_replacements:
-        query_complete = format_query(
-            raw_query=query,
-            replacements=query_replacements,
-            query_processor_name=query_processor_name,
-        )
-    else:
-        query_complete = query
-    print(f"\n⚠️  Query dispatch:\n{query_complete}")
-
-    # O disparo SF trabalha com o DataFrame plano retornado pela query.
-    # A query deve retornar as colunas: telefone, others (lista), e demais campos do disparo.
-    df = task_download_data_from_bigquery(
-        query=query_complete,
-        billing_project_id=billing_project_id,
-        bucket_name=billing_project_id,
+    # 1. Chamar a rota GET da SFMC REST API
+    records = fetch_sfmc_route(
+        route=route,
+        route_params=route_params,
+        query_params=query_params,
     )
 
-    if df is None or df.empty:
-        send_dispatch_no_destinations_found(id_hsm, campaign_name, cost_center_id, test_mode)
-        return
+    # 2. Montar DataFrame com colunas 'data' e 'data_particao'
+    df = build_dataframe(records=records)
 
-    # Valida colunas obrigatórias para o log SF: SubscriberKey e telefone.
-    # Lança ValueError imediatamente se alguma estiver ausente ou com dados inválidos.
-    validate_sf_dataframe(df, campaign_name)
-
-    print(f"Query retornou {len(df)} linhas. Colunas: {list(df.columns)}")
-
-    # Dedup por CPF — base para o loop de retentativas
-    if filter_duplicated_cpfs and "externalId" in df.columns:
-        n_before = len(df)
-        df = df.drop_duplicates(subset=["externalId"])
-        print(f"Removed {n_before - len(df)} duplicate CPFs. Remaining: {len(df)}")
-
-    if df.empty:
-        print("No destinations found after filtering duplicate CPFs. Exiting flow execution.")
-        return
-
-    # Remove telefones que falharam no último disparo
-    if filter_failed_phones:
-        # TODO: get_failed_phones queries fluxo_atendimento (Wetalkie). Substituir por tabela SF quando disponível.
-        # TODO: trocar externalId por SubscriberKey
-        failed_phones = get_failed_phones(billing_project_id=billing_project_id)
-        if failed_phones:
-            if max_dispatch_retries > 0:
-                # Marca como None para que o loop de retry use o próximo número de 'others'
-                df.loc[df["telefone"].isin(failed_phones), "telefone"] = None
-            else:
-                df = df[~df["telefone"].isin(failed_phones)]
-
-        if df.empty:
-            send_dispatch_no_destinations_found(id_hsm, campaign_name, cost_center_id, test_mode)
-            return
-
-    print(f"Total unique destinations to dispatch: {len(df)}")
-    base_df = df.copy()
-
-    # RETRY LOOP
-    for i in range(0, max_dispatch_retries + 1):
-
-        if i == 0:
-            current_df = base_df.copy()
-            # No primeiro disparo, exclui linhas com telefone None (marcadas por filter_failed_phones)
-            current_df = current_df.dropna(subset=["telefone"])
-        else:
-            if "others" in base_df.columns and not base_df["others"].apply(
-                lambda x: isinstance(x, list) and len(x) >= i
-            ).any():
-                print(f"✅ No others available for retry attempt {i}. Ending retry loop.")
-                break
-
-            print(f"⚠️  Sleep 3 minutes before retry dispatch.")
-            time.sleep(3 * 60)
-            print(f"\n⚠️  Starting retry attempt {i} for id_hsm={id_hsm}...")
-
-            # TODO: get_failed_cpfs queries fluxo_atendimento (Wetalkie). Substituir por tabela SF quando disponível.
-            failed_cpfs = get_failed_cpfs(billing_project_id=billing_project_id, id_hsm=id_hsm)
-
-            if not failed_cpfs:
-                print(f"✅ No failed CPFs found for retry attempt {i}. Ending retry loop.")
-                break
-
-            # Seleciona as linhas dos CPFs que falharam e aplica o próximo número de 'others'
-            retry_df = base_df[base_df["externalId"].isin(failed_cpfs)].copy()
-            if "others" not in retry_df.columns or retry_df.empty:
-                print(f"No others column or no rows for retry attempt {i}.")
-                break
-
-            retry_df["telefone"] = retry_df["others"].apply(
-                lambda x: x[i - 1] if isinstance(x, list) and len(x) >= i else None
-            )
-            current_df = retry_df.dropna(subset=["telefone"])
-
-            if current_df.empty:
-                print(f"✅ No retry phones available for attempt {i}. Ending retry loop.")
-                break
-
-            print(f"🚀 Found {len(current_df)} destinations for retry attempt {i}.")
-
-        # Filtro de já disparados
-        # No retry por CPF, desliga o filtro de CPF (o mesmo CPF deve tentar outro número)
-        current_filter = filter_dispatched_phones_or_cpfs
-        if i > 0 and current_filter == "cpf":
-            current_filter = None
-
-        if current_filter:
-            # TODO: fluxo_atendimento é tabela Wetalkie. Substituir por tabela de controle SF quando disponível.
-            print(f"🔍 Checking if phones were already dispatched today...")
-            already_dispatched_df = get_already_dispatched_data(billing_project_id=billing_project_id)
-            already_dispatched_df = already_dispatched_df.rename(columns={"celular_disparo": "telefone"})
-
-            n_before = len(current_df)
-            if current_filter == "cpf" and "externalId" in already_dispatched_df.columns:
-                dispatched_set = set(already_dispatched_df["externalId"].dropna().tolist())
-                current_df = current_df[~current_df["externalId"].isin(dispatched_set)]
-            elif current_filter == "phone_number" and "telefone" in already_dispatched_df.columns:
-                dispatched_set = set(already_dispatched_df["telefone"].dropna().tolist())
-                current_df = current_df[~current_df["telefone"].isin(dispatched_set)]
-            print(f"Removed {n_before - len(current_df)} already dispatched. Remaining: {len(current_df)}")
-
-        # Dedup por telefone (retries podem introduzir duplicatas)
-        if filter_duplicated_phones and "telefone" in current_df.columns:
-            n_before = len(current_df)
-            current_df = current_df.drop_duplicates(subset=["telefone"])
-            print(f"Removed {n_before - len(current_df)} duplicate phones.")
-
-        if current_df.empty:
-            print("No destinations found. Exiting flow execution.")
-            return
-
-        print(f"Total destinations for attempt {i}: {len(current_df)}")
-
-        # Whitelist (funções esperam List[Dict] com chave 'to')
-        if whitelist_percentage > 0:
-            whitelist_group_name = f"citizen-hsm-{campaign_name}"
-            whitelist_dests = [{"to": phone} for phone in current_df["telefone"].tolist()]
-            if whitelist_replace_contacts:
-                remove_contacts_from_whitelist(destinations=whitelist_dests, environment=whitelist_environment)
-            add_contacts_to_whitelist(
-                destinations=whitelist_dests,
-                percentage_to_insert=whitelist_percentage,
-                group_name=whitelist_group_name,
-                environment=whitelist_environment,
-                force_add_on_whitelist_group=force_add_on_whitelist_group,
-            )
-
-        print(f"\nStarting SF dispatch for id_hsm={id_hsm}, attempt={i}, campaign_name={campaign_name}")
-        print(f"Sample data:\n{current_df.head(2).to_dict('records')}")
-        print(f"⚠️  Sleep {sleep_minutes} minutes before dispatch. Check if event date and id_hsm is correct!!")
-        time.sleep(sleep_minutes * 60)
-
-        # Salva CSV (dropa 'others') e registra data do disparo
-        csv_path, dispatch_date = save_csv_for_sftp(
-            df=current_df,
-            data_extension_filename=data_extension_filename or campaign_name,
-        )
-
-        send_to_sftp(
-            csv_path=csv_path,
-            infisical_secret_path=infisical_secret_path,
-        )
-
-        print(f"CSV enviado para SFTP com {len(current_df)} destinatários na tentativa {i+1}.")
-
-        if not test_mode:
-            send_dispatch_success_notification(
-                total_dispatches=len(current_df),
-                dispatch_date=dispatch_date,
-                id_hsm=id_hsm,
-                campaign_name=campaign_name,
-                cost_center_id=cost_center_id,
-                total_batches=1,
-                sample_destination=(current_df.iloc[0].to_dict() if not current_df.empty else None),
-                test_mode=test_mode,
-                attempt_number=i + 1,
-                total_attempt_number=max_dispatch_retries + 1,
-            )
-
-            # Log para BQ: schema fixo com coluna `data` em JSON para camada bronze
-            log_df = create_log_df(
-                df=current_df,
-                dispatch_date=dispatch_date,
-                campaign_name=campaign_name,
-            )
-
-            partitions_path = create_date_partitions(
-                dataframe=log_df,
-                partition_column="dispatch_date",
-                file_format="csv",
-                root_folder="./data_dispatch/",
-            )
-
-            if not partitions_path:
-                raise ValueError("partitions_path is None - partition creation failed")
-
-            if not os.path.exists(partitions_path):
-                raise ValueError(f"partitions_path does not exist: {partitions_path}")
-
-            print(f"Generated partitions_path: {partitions_path}")
-            if os.path.exists(partitions_path):
-                files_in_path = []
-                for root, dirs, files in os.walk(partitions_path):  # pylint: disable=unused-variable
-                    files_in_path.extend([os.path.join(root, f) for f in files])
-                print(f"Files in partitions path: {files_in_path}")
-
-            create_table_and_upload_to_gcs_task(
-                data_path=partitions_path,
-                dataset_id=dataset_id,
-                table_id=table_id,
-                dump_mode=dump_mode,
-                biglake_table=False,
-            )
-
-
-
-@flow(log_prints=True, on_failure=[send_discord_notification_on_failure])
-def rj_crm__disparo_template(
-    # Parâmetros opcionais para override manual na UI.
-    id_hsm: int | None = None,
-    campaign_name: str | None = None,
-    cost_center_id: int | None = None,
-    chunk_size: int | None = None,
-    dataset_id: str | None = None,
-    table_id: str | None = None,
-    dump_mode: str | None = None,
-    test_mode: bool | None = True,
-    query: str | None = None,
-    query_processor_name: str | None = None,
-    query_replacements: dict | None = None,
-    filter_dispatched_phones_or_cpfs: str | None = "cpf",
-    filter_duplicated_phones: bool = True,
-    filter_duplicated_cpfs: bool = True,
-    filter_failed_phones: bool = False,
-    sleep_minutes: int | None = 5,
-    max_dispatch_retries: int = 0,
-    infisical_secret_path: str = "/wetalkie",
-    whitelist_percentage: int = 0,
-    whitelist_environment: str = "production",
-    flow_environment: str = "staging",
-    force_add_on_whitelist_group: bool = False,
-    whitelist_replace_contacts: bool = False,
-):
-    """
-    Orchestrates the dispatch of templated messages via Wetalkie API.
-
-    This flow handles fetching destinations, preparing dispatch payloads,
-    sending messages, and logging dispatch results to BigQuery.
-
-    Args:
-        id_hsm (int, optional): The ID of the HSM (Highly Structured Message) template to be used.
-        campaign_name (str, optional): The name of the dispatch campaign.
-        cost_center_id (int, optional): The ID of the cost center associated with the dispatch.
-        chunk_size (int, optional): The number of destinations to include in each dispatch batch.
-        dataset_id (str, optional): The BigQuery dataset ID where dispatch results will be stored.
-        table_id (str, optional): The BigQuery table ID where dispatch results will be stored.
-        dump_mode (str, optional): The mode for dumping data to BigQuery (e.g., "append", "overwrite").
-        test_mode (bool, optional): If True, the flow runs in test mode, dispatching only to test numbers. Defaults to True.
-        query (str, optional): The SQL query used to retrieve the list of destinations for dispatch.
-        query_processor_name (str, optional): The name of the processor to format the query.
-        query_replacements (dict, optional): A dictionary of key-value pairs to replace placeholders in the `query`. Defaults to None.
-        filter_dispatched_phones_or_cpfs (str, optional): If True, filters out phone numbers that have already been dispatched today. This parameter must be None, "cpf" or "phone_number". Defaults to "cpf".
-        filter_duplicated_phones (bool, optional): If True, removes duplicate phone numbers from the destination list. Defaults to True.
-        filter_duplicated_cpfs (bool, optional): If True, removes duplicate CPFs from the destination list. Defaults to True.
-        filter_failed_phones (bool, optional): If True, removes phone numbers that have already failed in last dispatch. Defaults to False.
-        sleep_minutes (int, optional): The number of minutes to wait before initiating the dispatch. Defaults to 5.
-        max_dispatch_retries (int): Maximum number of retry attempts using alternative phone numbers. Defaults to 0.
-        infisical_secret_path (str, optional): The path in Infisical where Wetalkie API secrets are stored. Defaults to "/wetalkie".
-        whitelist_percentage (int, optional): The percentage of contacts to add to a whitelist group. Defaults to 0.
-        whitelist_environment (str, optional): The environment for the whitelist (e.g., "staging", "production"). Defaults to "staging".
-        flow_environment (str, optional): The environment where the flow is running (e.g., "staging", "production"). Defaults to "staging".
-        force_add_on_whitelist_group (bool, optional): If True, forces adding contacts to the whitelist group. Defaults to False.
-        whitelist_replace_contacts (bool, optional): If True, removes contacts from the whitelist before adding them. Defaults to True.
-    """
-    # force deploy ##
-
-    dataset_id = dataset_id or TemplateConstants.DATASET_ID.value
-    table_id = table_id or TemplateConstants.TABLE_ID.value
-    dump_mode = dump_mode or TemplateConstants.DUMP_MODE.value
-    id_hsm = id_hsm or TemplateConstants.ID_HSM.value
-    campaign_name = campaign_name or TemplateConstants.CAMPAIGN_NAME.value
-    cost_center_id = cost_center_id or TemplateConstants.COST_CENTER_ID.value
-    chunk_size = chunk_size or TemplateConstants.CHUNK_SIZE.value
-    query = query or TemplateConstants.QUERY.value
-    query_processor_name = query_processor_name or TemplateConstants.QUERY_PROCESSOR_NAME.value
-    billing_project_id = TemplateConstants.BILLING_PROJECT_ID.value
-
-    destinations = getenv_or_action("TEMPLATE__DESTINATIONS", action="ignore")
-
-    rename_flow_run = rename_current_flow_run_task(new_name=f"{table_id}_{dataset_id}")  # pylint: disable=unused-variable
-    crd = inject_bd_credentials_task(environment="prod")  # noqa  # pylint: disable=unused-variable
-
-    flow_status = check_flow_status(
-        flow_environment=flow_environment,
-        billing_project_id=billing_project_id,
-        bucket_name=billing_project_id,
-        id_hsm=id_hsm,
-        campaign_name=campaign_name,
-    )
-    if flow_status is None:
-        print("Ending flow due to inactive status.")
-        return  # flow termina aqui, nada downstream é agendado
-
-    if test_mode:
-        campaign_name = "teste-"+campaign_name
-        print("⚠️  MODO DE TESTE ATIVADO - Disparos para números de teste apenas")
-        # force deploy
-
-    api = access_api(
-        infisical_secret_path,
-        "wetalkie_url",
-        "wetalkie_user",
-        "wetalkie_pass",
-        login_route="users/login",
+    # 3. Criar partições por data
+    partitions_path = create_date_partitions(
+        dataframe=df,
+        partition_column=partition_column,
+        file_format=file_format,
+        root_folder=f"{root_folder}/{table_id}",
     )
 
-    api_status = check_api_status(api)
+    print(f"[SFMC] Partitions path gerado: {partitions_path}")
+    if os.path.exists(partitions_path):
+        files_in_path = []
+        for root, dirs, files in os.walk(partitions_path):
+            files_in_path.extend([os.path.join(root, f) for f in files])
+        print(f"[SFMC] Arquivos gerados: {files_in_path}")
 
-    if query_replacements:
-        query_complete = format_query(
-            raw_query=query,
-            replacements=query_replacements,
-            query_processor_name=query_processor_name,
-        )
-    else:
-        query_complete = query
-    print(f"\n⚠️  Query dispatch:\n{query_complete}")
-
-    destinations_result = get_destinations(
-        destinations=destinations,
-        query=query_complete,
-        billing_project_id=billing_project_id,
+    # 4. Upload para GCS / BigQuery
+    create_table_and_upload_to_gcs_task(
+        data_path=partitions_path,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        dump_mode=dump_mode,
+        biglake_table=False,
     )
-
-    if destinations_result is None or len(destinations_result) == 0:
-        send_dispatch_no_destinations_found(
-            id_hsm,
-            campaign_name,
-            cost_center_id,
-            test_mode
-        )
-        return  # flow termina aqui, nada downstream é agendado
-
-    # Remove duplicate CPFs if flag is set - This is our BASE list for retries
-    remove_duplicate_destinations = remove_duplicate_cpfs(destinations_result) if filter_duplicated_cpfs else destinations_result
-    if not remove_duplicate_destinations or len(remove_duplicate_destinations) == 0:
-        print("No destinations found after filtering duplicate CPFs. Exiting flow execution.")
-        return
-
-    if filter_failed_phones:
-        base_destinations = remove_failed_phones(
-            original_destinations=remove_duplicate_destinations,
-            billing_project_id=billing_project_id,
-            max_dispatch_retries=max_dispatch_retries,
-        )
-    else:
-        base_destinations = remove_duplicate_destinations
-
-    if not base_destinations or len(base_destinations) == 0:
-        print("No destinations found after filtering failed phones. Exiting flow execution.")
-        send_dispatch_no_destinations_found(
-            id_hsm,
-            campaign_name,
-            cost_center_id,
-            test_mode,
-        )
-        return
-
-    print(f"Total unique destinations to dispatch: {len(base_destinations)}")
-
-    if not api_status:
-        print("API is not accessible. Ending flow execution.")
-        return
-    
-    # Destinos que serão processados na iteração atual do loop
-    current_attempt_destinations = base_destinations
-
-    # RETRY LOOP
-    for i in range(0, max_dispatch_retries + 1):
-        
-        if (i > 0 or filter_failed_phones) and max_dispatch_retries > 0:
-            if i > 0:
-                print(f"⚠️  Sleep 5 minutes before retry dispatch.")
-                time.sleep(3 * 60)
-
-                print(f"\n⚠️  Starting retry attempt {i} for id_hsm={id_hsm}. Checking for remaining failures...")
-            else:
-                print(f"\n⚠️  Fill with others phones for previously failed phones.")
-            retry_destinations = get_retry_destinations(
-                id_hsm=id_hsm,
-                original_destinations=base_destinations,
-                billing_project_id=billing_project_id,
-                attempt_number=i
-            )
-
-            if not retry_destinations or len(retry_destinations) == 0:
-                print(f"✅ No remaining phones found for retry attempt {i}. Ending retry loop.")
-                break
-
-            print(f"🚀 Found {len(retry_destinations)} destinations for retry attempt {i}.")
-            current_attempt_destinations = retry_destinations
-
-            filter_dispatched_phones_or_cpfs = None if filter_dispatched_phones_or_cpfs == "cpf" else filter_dispatched_phones_or_cpfs
-
-        if filter_dispatched_phones_or_cpfs:
-            # 1. Primeiro Disparo (i=1): O filtro original (seja por CPF ou por Telefone) é aplicado normalmente, garantindo que ninguém que
-            # já tenha recebido a mensagem hoje seja processado.
-            # 2. Repescagem (i > 1):
-            #     * Se o filtro era por CPF, ele é desativado (None), pois o CPF já foi "tentado" no passo anterior e agora o objetivo é
-            #       justamente tentar outro número para esse mesmo CPF.
-            #     * Se o filtro era por Telefone, ele é mantido, garantindo que o novo número escolhido da lista others seja verificado no
-            #       BigQuery. Se esse número específico já tiver recebido um disparo (por outra campanha, por exemplo), ele será filtrado.
-
-            print(f"🔍 Checking if phone numbers were already dispatched today...")
-            already_dispatched_data = get_already_dispatched_data(billing_project_id=billing_project_id)
-            current_attempt_destinations = filter_already_dispatched_phones_or_cpfs(
-                destinations=current_attempt_destinations,
-                already_dispatched_df=already_dispatched_data,
-                field=filter_dispatched_phones_or_cpfs
-            )
-
-        # Filter duplicates (important as 'others' inside retries might have repetitions)
-        final_destinations = remove_duplicate_phones(current_attempt_destinations) if filter_duplicated_phones else current_attempt_destinations
-
-        if not final_destinations or len(final_destinations) == 0:
-            print("No destinations found. Exiting flow execution.")
-            return
-
-        # Add contacts to whitelist if percentage is set
-        if whitelist_percentage > 0:
-            whitelist_group_name = f"citizen-hsm-{campaign_name}"
-            if whitelist_replace_contacts:
-                remove_contacts_from_whitelist(
-                    destinations=final_destinations,
-                    environment=whitelist_environment,
-                )
-            add_contacts_to_whitelist(
-                destinations=final_destinations,
-                percentage_to_insert=whitelist_percentage,
-                group_name=whitelist_group_name,
-                environment=whitelist_environment,
-                force_add_on_whitelist_group=force_add_on_whitelist_group,
-            )
-            
-        dispatch_payload = create_dispatch_payload(
-            campaign_name=campaign_name,
-            cost_center_id=cost_center_id,
-            destinations=final_destinations,
-        )
-
-        print(
-            f"\nStarting dispatch for id_hsm={id_hsm}, attempt={i}, campaign_name={campaign_name}, example data {final_destinations[:5]}\n"
-        )
-        print(f"⚠️  Sleep {sleep_minutes} minutes before dispatch. Check if event date and id_hsm is correct!!")
-        time.sleep(sleep_minutes * 60)
-
-        dispatch_date = dispatch(
-            api=api,
-            id_hsm=id_hsm,
-            dispatch_payload=dispatch_payload,
-            chunk=chunk_size,
-        )
-
-        print(f"Dispatch completed successfully for {len(final_destinations)} destinations on attempt {i+1}.")
-
-        total_batches = ceil(len(final_destinations) / chunk_size)
-
-        dfr = create_dispatch_dfr(
-            id_hsm=id_hsm,
-            original_destinations=final_destinations,
-            campaign_name=campaign_name,
-            cost_center_id=cost_center_id,
-            dispatch_date=dispatch_date,
-        )
-
-        print(f"DataFrame created with {len(dfr)} records for BigQuery upload")
-
-        if not test_mode:
-            # Send Discord notification for attempt
-            send_dispatch_success_notification(
-                total_dispatches=len(final_destinations),
-                dispatch_date=dispatch_date,
-                id_hsm=id_hsm,
-                campaign_name=campaign_name,
-                cost_center_id=cost_center_id,
-                total_batches=total_batches,
-                sample_destination=(final_destinations[0] if final_destinations else None),
-                test_mode=test_mode,
-                # whitelist_percentage=whitelist_percentage,
-                attempt_number=i + 1,  # Exibe 1 para o primeiro disparo, 2 para o retry...
-                total_attempt_number=max_dispatch_retries + 1,
-            )
-
-            partitions_path = create_date_partitions(
-                dataframe=dfr,
-                partition_column="dispatch_date",
-                file_format="csv",
-                root_folder="./data_dispatch/",
-            )
-
-            if not partitions_path:
-                raise ValueError("partitions_path is None - partition creation failed")
-
-            if not os.path.exists(partitions_path):
-                raise ValueError(f"partitions_path does not exist: {partitions_path}")
-
-            print(f"Generated partitions_path: {partitions_path}")
-            if os.path.exists(partitions_path):
-                files_in_path = []
-                for root, dirs, files in os.walk(partitions_path):  # pylint: disable=unused-variable
-                    files_in_path.extend([os.path.join(root, f) for f in files])
-                print(f"Files in partitions path: {files_in_path}")
-
-            create_table_and_upload_to_gcs_task(
-                data_path=partitions_path,
-                dataset_id=dataset_id,
-                table_id=table_id,
-                dump_mode=dump_mode,
-                biglake_table=False,
-            )

--- a/pipelines/rj_crm__salesforce_api/flow.py
+++ b/pipelines/rj_crm__salesforce_api/flow.py
@@ -83,6 +83,7 @@ def rj_crm__salesforce_api(
     inject_bd_credentials_task(environment="prod")
 
     # 1. Chamar a rota da SFMC REST API (GET ou POST, com paginação automática)
+    # force deploy
     records = fetch_sfmc_route(
         route=route,
         http_method=http_method,

--- a/pipelines/rj_crm__salesforce_api/flow.py
+++ b/pipelines/rj_crm__salesforce_api/flow.py
@@ -1,0 +1,700 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa:E501
+# pylint: disable='line-too-long'
+
+"""
+Flow to dispatch templated messages via Wetalkie API
+"""
+import os
+import time
+from math import ceil
+import pendulum
+
+from iplanrio.pipelines_utils.bd import create_table_and_upload_to_gcs_task  # pylint: disable=E0611, E0401
+from iplanrio.pipelines_utils.env import getenv_or_action, inject_bd_credentials_task  # pylint: disable=E0611, E0401
+from iplanrio.pipelines_utils.prefect import rename_current_flow_run_task  # pylint: disable=E0611, E0401
+from prefect import flow  # pylint: disable=E0611, E0401
+from prefect.client.schemas.objects import Flow, FlowRun, State  # pylint: disable=E0611, E0401
+
+from pipelines.rj_crm__disparo_template.constants import TemplateConstants  # pylint: disable=E0611, E0401
+# pylint: disable=E0611, E0401
+from pipelines.rj_crm__disparo_template.utils.discord import (
+    send_dispatch_no_destinations_found,
+    # send_retry_dispatch_result_notification,
+    send_dispatch_success_notification,
+    send_discord_notification,
+)
+# pylint: disable=E0611, E0401
+from pipelines.rj_crm__disparo_template.utils.dispatch import (
+    add_contacts_to_whitelist,
+    check_api_status,
+    check_flow_status,
+    create_dispatch_dfr,
+    create_dispatch_payload,
+    create_log_df,
+    dispatch,
+    filter_already_dispatched_phones_or_cpfs,
+    format_query,
+    get_already_dispatched_data,
+    get_destinations,
+    get_failed_cpfs,
+    get_failed_phones,
+    get_retry_destinations,
+    remove_contacts_from_whitelist,
+    remove_duplicate_cpfs,
+    remove_duplicate_phones,
+    remove_failed_phones,
+    save_csv_for_sftp,
+    send_to_sftp,
+)
+# pylint: disable=E0611, E0401
+from pipelines.rj_crm__disparo_template.utils.validators import validate_sf_dataframe
+# pylint: disable=E0611, E0401
+from pipelines.rj_crm__disparo_template.utils.tasks import (
+    access_api,
+    create_date_partitions,
+    task_download_data_from_bigquery,
+)
+
+
+def send_discord_notification_on_failure(flow: Flow, flow_run: FlowRun, state: State):
+    """
+    Sends a Discord notification when a flow run fails.
+    """
+    # Only send notification if flow_environment is production
+    flow_environment = flow_run.parameters.get("flow_environment", "staging")
+    if flow_environment != "production":
+        print(f"Flow failed in {flow_environment} environment. Skipping Discord notification.")
+        return
+
+    webhook_url = os.getenv("DISCORD_WEBHOOK_URL_ERRORS")
+    if not webhook_url:
+        print("DISCORD_WEBHOOK_URL_ERRORS environment variable not set on Infisical. Cannot send notification.")
+        return
+
+    campaign_name = flow_run.parameters.get("campaign_name", "N/A")
+    id_hsm = flow_run.parameters.get("id_hsm", "N/A")
+    cost_center_id = flow_run.parameters.get("cost_center_id", "N/A")
+
+    message = f"""
+    Prefect flow run failed in PRODUCTION! 🚨
+    📋 **Campanha:** {campaign_name}
+    🆔 **Template ID:** {id_hsm}
+    💰 **Centro de Custo:** {cost_center_id}
+    ⚠️ **Mensagem:** {state.message}
+    """
+    send_discord_notification(webhook_url, message)
+
+# force deploy
+@flow(log_prints=True, on_failure=[send_discord_notification_on_failure])
+def rj_crm__disparo_template_sf(
+    # Parâmetros opcionais para override manual na UI.
+    id_hsm: int | None = None,
+    campaign_name: str | None = None,
+    cost_center_id: int | None = None,
+    dataset_id: str | None = None,
+    table_id: str | None = None,
+    dump_mode: str | None = None,
+    test_mode: bool | None = True,
+    query: str | None = None,
+    query_processor_name: str | None = None,
+    query_replacements: dict | None = None,
+    filter_dispatched_phones_or_cpfs: str | None = "cpf",
+    filter_duplicated_phones: bool = True,
+    filter_duplicated_cpfs: bool = True,
+    filter_failed_phones: bool = False,
+    sleep_minutes: int | None = 5,
+    max_dispatch_retries: int = 0,
+    infisical_secret_path: str = "/crm_disparo_template",
+    data_extension_filename: str | None = None,
+    whitelist_percentage: int = 0,
+    whitelist_environment: str = "production",
+    flow_environment: str = "staging",
+    force_add_on_whitelist_group: bool = False,
+    whitelist_replace_contacts: bool = False,
+):
+    """
+    Orchestrates the dispatch of templated messages via Salesforce SFTP.
+
+    Fetches destinations from BigQuery, applies filters, generates a CSV with
+    a 'telefone' plus all query fields, saves it to
+    disk, and uploads it to the configured SFTP server.
+    Dispatch results are also logged to BigQuery.
+
+    SFTP credentials (sf_sftp_host, sf_sftp_user, sf_sftp_password) must be available
+    as environment variables injected from Infisical at infisical_secret_path.
+
+    Args:
+        id_hsm (int, optional): The ID of the HSM template.
+        campaign_name (str, optional): The name of the dispatch campaign.
+        cost_center_id (int, optional): The ID of the cost center.
+        chunk_size (int, optional): Kept for interface compatibility; not used for SFTP batching.
+        dataset_id (str, optional): BigQuery dataset ID for dispatch logs.
+        table_id (str, optional): BigQuery table ID for dispatch logs.
+        dump_mode (str, optional): BigQuery dump mode (e.g., "append").
+        test_mode (bool, optional): If True, runs in test mode. Defaults to True.
+        query (str, optional): SQL query to retrieve destinations.
+        query_processor_name (str, optional): Name of the query processor.
+        query_replacements (dict, optional): Replacements for query placeholders.
+        filter_dispatched_phones_or_cpfs (str, optional): None, "cpf" or "phone_number". Defaults to "cpf".
+        filter_duplicated_phones (bool, optional): Remove duplicate phones. Defaults to True.
+        filter_duplicated_cpfs (bool, optional): Remove duplicate CPFs. Defaults to True.
+        filter_failed_phones (bool, optional): Remove phones that failed in last dispatch. Defaults to False.
+        sleep_minutes (int, optional): Minutes to sleep before dispatch. Defaults to 5.
+        max_dispatch_retries (int): Maximum retry attempts with alternative phones. Defaults to 0.
+        infisical_secret_path (str, optional): Infisical path for SFTP credentials. Defaults to "/sftp".
+        sftp_remote_path (str, optional): Remote directory on the SFTP server. Defaults to "/".
+        whitelist_percentage (int, optional): Percentage of contacts to whitelist. Defaults to 0.
+        whitelist_environment (str, optional): Whitelist environment. Defaults to "production".
+        flow_environment (str, optional): Flow environment ("staging" or "production"). Defaults to "staging".
+        force_add_on_whitelist_group (bool, optional): Force add to whitelist group. Defaults to False.
+        whitelist_replace_contacts (bool, optional): Remove contacts before adding to whitelist. Defaults to False.
+    """
+
+    dataset_id = dataset_id or TemplateConstants.DATASET_ID.value
+    table_id = table_id or TemplateConstants.TABLE_ID.value
+    dump_mode = dump_mode or TemplateConstants.DUMP_MODE.value
+    id_hsm = id_hsm or TemplateConstants.ID_HSM.value
+    campaign_name = campaign_name or TemplateConstants.CAMPAIGN_NAME.value
+    cost_center_id = cost_center_id or TemplateConstants.COST_CENTER_ID.value
+    query = query or TemplateConstants.QUERY.value
+    query_processor_name = query_processor_name or TemplateConstants.QUERY_PROCESSOR_NAME.value
+    billing_project_id = TemplateConstants.BILLING_PROJECT_ID.value
+
+    rename_flow_run = rename_current_flow_run_task(new_name=f"{table_id}_{dataset_id}")  # pylint: disable=unused-variable
+    crd = inject_bd_credentials_task(environment="prod")  # noqa  # pylint: disable=unused-variable
+
+    flow_status = check_flow_status(
+        flow_environment=flow_environment,
+        billing_project_id=billing_project_id,
+        bucket_name=billing_project_id,
+        id_hsm=id_hsm,
+        campaign_name=campaign_name,
+    )
+    if flow_status is None:
+        print("Ending flow due to inactive status.")
+        return
+
+    if test_mode:
+        campaign_name = "teste-" + campaign_name
+        print("⚠️  MODO DE TESTE ATIVADO - Disparos para números de teste apenas")
+
+    if query_replacements:
+        query_complete = format_query(
+            raw_query=query,
+            replacements=query_replacements,
+            query_processor_name=query_processor_name,
+        )
+    else:
+        query_complete = query
+    print(f"\n⚠️  Query dispatch:\n{query_complete}")
+
+    # O disparo SF trabalha com o DataFrame plano retornado pela query.
+    # A query deve retornar as colunas: telefone, others (lista), e demais campos do disparo.
+    df = task_download_data_from_bigquery(
+        query=query_complete,
+        billing_project_id=billing_project_id,
+        bucket_name=billing_project_id,
+    )
+
+    if df is None or df.empty:
+        send_dispatch_no_destinations_found(id_hsm, campaign_name, cost_center_id, test_mode)
+        return
+
+    # Valida colunas obrigatórias para o log SF: SubscriberKey e telefone.
+    # Lança ValueError imediatamente se alguma estiver ausente ou com dados inválidos.
+    validate_sf_dataframe(df, campaign_name)
+
+    print(f"Query retornou {len(df)} linhas. Colunas: {list(df.columns)}")
+
+    # Dedup por CPF — base para o loop de retentativas
+    if filter_duplicated_cpfs and "externalId" in df.columns:
+        n_before = len(df)
+        df = df.drop_duplicates(subset=["externalId"])
+        print(f"Removed {n_before - len(df)} duplicate CPFs. Remaining: {len(df)}")
+
+    if df.empty:
+        print("No destinations found after filtering duplicate CPFs. Exiting flow execution.")
+        return
+
+    # Remove telefones que falharam no último disparo
+    if filter_failed_phones:
+        # TODO: get_failed_phones queries fluxo_atendimento (Wetalkie). Substituir por tabela SF quando disponível.
+        # TODO: trocar externalId por SubscriberKey
+        failed_phones = get_failed_phones(billing_project_id=billing_project_id)
+        if failed_phones:
+            if max_dispatch_retries > 0:
+                # Marca como None para que o loop de retry use o próximo número de 'others'
+                df.loc[df["telefone"].isin(failed_phones), "telefone"] = None
+            else:
+                df = df[~df["telefone"].isin(failed_phones)]
+
+        if df.empty:
+            send_dispatch_no_destinations_found(id_hsm, campaign_name, cost_center_id, test_mode)
+            return
+
+    print(f"Total unique destinations to dispatch: {len(df)}")
+    base_df = df.copy()
+
+    # RETRY LOOP
+    for i in range(0, max_dispatch_retries + 1):
+
+        if i == 0:
+            current_df = base_df.copy()
+            # No primeiro disparo, exclui linhas com telefone None (marcadas por filter_failed_phones)
+            current_df = current_df.dropna(subset=["telefone"])
+        else:
+            if "others" in base_df.columns and not base_df["others"].apply(
+                lambda x: isinstance(x, list) and len(x) >= i
+            ).any():
+                print(f"✅ No others available for retry attempt {i}. Ending retry loop.")
+                break
+
+            print(f"⚠️  Sleep 3 minutes before retry dispatch.")
+            time.sleep(3 * 60)
+            print(f"\n⚠️  Starting retry attempt {i} for id_hsm={id_hsm}...")
+
+            # TODO: get_failed_cpfs queries fluxo_atendimento (Wetalkie). Substituir por tabela SF quando disponível.
+            failed_cpfs = get_failed_cpfs(billing_project_id=billing_project_id, id_hsm=id_hsm)
+
+            if not failed_cpfs:
+                print(f"✅ No failed CPFs found for retry attempt {i}. Ending retry loop.")
+                break
+
+            # Seleciona as linhas dos CPFs que falharam e aplica o próximo número de 'others'
+            retry_df = base_df[base_df["externalId"].isin(failed_cpfs)].copy()
+            if "others" not in retry_df.columns or retry_df.empty:
+                print(f"No others column or no rows for retry attempt {i}.")
+                break
+
+            retry_df["telefone"] = retry_df["others"].apply(
+                lambda x: x[i - 1] if isinstance(x, list) and len(x) >= i else None
+            )
+            current_df = retry_df.dropna(subset=["telefone"])
+
+            if current_df.empty:
+                print(f"✅ No retry phones available for attempt {i}. Ending retry loop.")
+                break
+
+            print(f"🚀 Found {len(current_df)} destinations for retry attempt {i}.")
+
+        # Filtro de já disparados
+        # No retry por CPF, desliga o filtro de CPF (o mesmo CPF deve tentar outro número)
+        current_filter = filter_dispatched_phones_or_cpfs
+        if i > 0 and current_filter == "cpf":
+            current_filter = None
+
+        if current_filter:
+            # TODO: fluxo_atendimento é tabela Wetalkie. Substituir por tabela de controle SF quando disponível.
+            print(f"🔍 Checking if phones were already dispatched today...")
+            already_dispatched_df = get_already_dispatched_data(billing_project_id=billing_project_id)
+            already_dispatched_df = already_dispatched_df.rename(columns={"celular_disparo": "telefone"})
+
+            n_before = len(current_df)
+            if current_filter == "cpf" and "externalId" in already_dispatched_df.columns:
+                dispatched_set = set(already_dispatched_df["externalId"].dropna().tolist())
+                current_df = current_df[~current_df["externalId"].isin(dispatched_set)]
+            elif current_filter == "phone_number" and "telefone" in already_dispatched_df.columns:
+                dispatched_set = set(already_dispatched_df["telefone"].dropna().tolist())
+                current_df = current_df[~current_df["telefone"].isin(dispatched_set)]
+            print(f"Removed {n_before - len(current_df)} already dispatched. Remaining: {len(current_df)}")
+
+        # Dedup por telefone (retries podem introduzir duplicatas)
+        if filter_duplicated_phones and "telefone" in current_df.columns:
+            n_before = len(current_df)
+            current_df = current_df.drop_duplicates(subset=["telefone"])
+            print(f"Removed {n_before - len(current_df)} duplicate phones.")
+
+        if current_df.empty:
+            print("No destinations found. Exiting flow execution.")
+            return
+
+        print(f"Total destinations for attempt {i}: {len(current_df)}")
+
+        # Whitelist (funções esperam List[Dict] com chave 'to')
+        if whitelist_percentage > 0:
+            whitelist_group_name = f"citizen-hsm-{campaign_name}"
+            whitelist_dests = [{"to": phone} for phone in current_df["telefone"].tolist()]
+            if whitelist_replace_contacts:
+                remove_contacts_from_whitelist(destinations=whitelist_dests, environment=whitelist_environment)
+            add_contacts_to_whitelist(
+                destinations=whitelist_dests,
+                percentage_to_insert=whitelist_percentage,
+                group_name=whitelist_group_name,
+                environment=whitelist_environment,
+                force_add_on_whitelist_group=force_add_on_whitelist_group,
+            )
+
+        print(f"\nStarting SF dispatch for id_hsm={id_hsm}, attempt={i}, campaign_name={campaign_name}")
+        print(f"Sample data:\n{current_df.head(2).to_dict('records')}")
+        print(f"⚠️  Sleep {sleep_minutes} minutes before dispatch. Check if event date and id_hsm is correct!!")
+        time.sleep(sleep_minutes * 60)
+
+        # Salva CSV (dropa 'others') e registra data do disparo
+        csv_path, dispatch_date = save_csv_for_sftp(
+            df=current_df,
+            data_extension_filename=data_extension_filename or campaign_name,
+        )
+
+        send_to_sftp(
+            csv_path=csv_path,
+            infisical_secret_path=infisical_secret_path,
+        )
+
+        print(f"CSV enviado para SFTP com {len(current_df)} destinatários na tentativa {i+1}.")
+
+        if not test_mode:
+            send_dispatch_success_notification(
+                total_dispatches=len(current_df),
+                dispatch_date=dispatch_date,
+                id_hsm=id_hsm,
+                campaign_name=campaign_name,
+                cost_center_id=cost_center_id,
+                total_batches=1,
+                sample_destination=(current_df.iloc[0].to_dict() if not current_df.empty else None),
+                test_mode=test_mode,
+                attempt_number=i + 1,
+                total_attempt_number=max_dispatch_retries + 1,
+            )
+
+            # Log para BQ: schema fixo com coluna `data` em JSON para camada bronze
+            log_df = create_log_df(
+                df=current_df,
+                dispatch_date=dispatch_date,
+                campaign_name=campaign_name,
+            )
+
+            partitions_path = create_date_partitions(
+                dataframe=log_df,
+                partition_column="dispatch_date",
+                file_format="csv",
+                root_folder="./data_dispatch/",
+            )
+
+            if not partitions_path:
+                raise ValueError("partitions_path is None - partition creation failed")
+
+            if not os.path.exists(partitions_path):
+                raise ValueError(f"partitions_path does not exist: {partitions_path}")
+
+            print(f"Generated partitions_path: {partitions_path}")
+            if os.path.exists(partitions_path):
+                files_in_path = []
+                for root, dirs, files in os.walk(partitions_path):  # pylint: disable=unused-variable
+                    files_in_path.extend([os.path.join(root, f) for f in files])
+                print(f"Files in partitions path: {files_in_path}")
+
+            create_table_and_upload_to_gcs_task(
+                data_path=partitions_path,
+                dataset_id=dataset_id,
+                table_id=table_id,
+                dump_mode=dump_mode,
+                biglake_table=False,
+            )
+
+
+
+@flow(log_prints=True, on_failure=[send_discord_notification_on_failure])
+def rj_crm__disparo_template(
+    # Parâmetros opcionais para override manual na UI.
+    id_hsm: int | None = None,
+    campaign_name: str | None = None,
+    cost_center_id: int | None = None,
+    chunk_size: int | None = None,
+    dataset_id: str | None = None,
+    table_id: str | None = None,
+    dump_mode: str | None = None,
+    test_mode: bool | None = True,
+    query: str | None = None,
+    query_processor_name: str | None = None,
+    query_replacements: dict | None = None,
+    filter_dispatched_phones_or_cpfs: str | None = "cpf",
+    filter_duplicated_phones: bool = True,
+    filter_duplicated_cpfs: bool = True,
+    filter_failed_phones: bool = False,
+    sleep_minutes: int | None = 5,
+    max_dispatch_retries: int = 0,
+    infisical_secret_path: str = "/wetalkie",
+    whitelist_percentage: int = 0,
+    whitelist_environment: str = "production",
+    flow_environment: str = "staging",
+    force_add_on_whitelist_group: bool = False,
+    whitelist_replace_contacts: bool = False,
+):
+    """
+    Orchestrates the dispatch of templated messages via Wetalkie API.
+
+    This flow handles fetching destinations, preparing dispatch payloads,
+    sending messages, and logging dispatch results to BigQuery.
+
+    Args:
+        id_hsm (int, optional): The ID of the HSM (Highly Structured Message) template to be used.
+        campaign_name (str, optional): The name of the dispatch campaign.
+        cost_center_id (int, optional): The ID of the cost center associated with the dispatch.
+        chunk_size (int, optional): The number of destinations to include in each dispatch batch.
+        dataset_id (str, optional): The BigQuery dataset ID where dispatch results will be stored.
+        table_id (str, optional): The BigQuery table ID where dispatch results will be stored.
+        dump_mode (str, optional): The mode for dumping data to BigQuery (e.g., "append", "overwrite").
+        test_mode (bool, optional): If True, the flow runs in test mode, dispatching only to test numbers. Defaults to True.
+        query (str, optional): The SQL query used to retrieve the list of destinations for dispatch.
+        query_processor_name (str, optional): The name of the processor to format the query.
+        query_replacements (dict, optional): A dictionary of key-value pairs to replace placeholders in the `query`. Defaults to None.
+        filter_dispatched_phones_or_cpfs (str, optional): If True, filters out phone numbers that have already been dispatched today. This parameter must be None, "cpf" or "phone_number". Defaults to "cpf".
+        filter_duplicated_phones (bool, optional): If True, removes duplicate phone numbers from the destination list. Defaults to True.
+        filter_duplicated_cpfs (bool, optional): If True, removes duplicate CPFs from the destination list. Defaults to True.
+        filter_failed_phones (bool, optional): If True, removes phone numbers that have already failed in last dispatch. Defaults to False.
+        sleep_minutes (int, optional): The number of minutes to wait before initiating the dispatch. Defaults to 5.
+        max_dispatch_retries (int): Maximum number of retry attempts using alternative phone numbers. Defaults to 0.
+        infisical_secret_path (str, optional): The path in Infisical where Wetalkie API secrets are stored. Defaults to "/wetalkie".
+        whitelist_percentage (int, optional): The percentage of contacts to add to a whitelist group. Defaults to 0.
+        whitelist_environment (str, optional): The environment for the whitelist (e.g., "staging", "production"). Defaults to "staging".
+        flow_environment (str, optional): The environment where the flow is running (e.g., "staging", "production"). Defaults to "staging".
+        force_add_on_whitelist_group (bool, optional): If True, forces adding contacts to the whitelist group. Defaults to False.
+        whitelist_replace_contacts (bool, optional): If True, removes contacts from the whitelist before adding them. Defaults to True.
+    """
+    # force deploy ##
+
+    dataset_id = dataset_id or TemplateConstants.DATASET_ID.value
+    table_id = table_id or TemplateConstants.TABLE_ID.value
+    dump_mode = dump_mode or TemplateConstants.DUMP_MODE.value
+    id_hsm = id_hsm or TemplateConstants.ID_HSM.value
+    campaign_name = campaign_name or TemplateConstants.CAMPAIGN_NAME.value
+    cost_center_id = cost_center_id or TemplateConstants.COST_CENTER_ID.value
+    chunk_size = chunk_size or TemplateConstants.CHUNK_SIZE.value
+    query = query or TemplateConstants.QUERY.value
+    query_processor_name = query_processor_name or TemplateConstants.QUERY_PROCESSOR_NAME.value
+    billing_project_id = TemplateConstants.BILLING_PROJECT_ID.value
+
+    destinations = getenv_or_action("TEMPLATE__DESTINATIONS", action="ignore")
+
+    rename_flow_run = rename_current_flow_run_task(new_name=f"{table_id}_{dataset_id}")  # pylint: disable=unused-variable
+    crd = inject_bd_credentials_task(environment="prod")  # noqa  # pylint: disable=unused-variable
+
+    flow_status = check_flow_status(
+        flow_environment=flow_environment,
+        billing_project_id=billing_project_id,
+        bucket_name=billing_project_id,
+        id_hsm=id_hsm,
+        campaign_name=campaign_name,
+    )
+    if flow_status is None:
+        print("Ending flow due to inactive status.")
+        return  # flow termina aqui, nada downstream é agendado
+
+    if test_mode:
+        campaign_name = "teste-"+campaign_name
+        print("⚠️  MODO DE TESTE ATIVADO - Disparos para números de teste apenas")
+        # force deploy
+
+    api = access_api(
+        infisical_secret_path,
+        "wetalkie_url",
+        "wetalkie_user",
+        "wetalkie_pass",
+        login_route="users/login",
+    )
+
+    api_status = check_api_status(api)
+
+    if query_replacements:
+        query_complete = format_query(
+            raw_query=query,
+            replacements=query_replacements,
+            query_processor_name=query_processor_name,
+        )
+    else:
+        query_complete = query
+    print(f"\n⚠️  Query dispatch:\n{query_complete}")
+
+    destinations_result = get_destinations(
+        destinations=destinations,
+        query=query_complete,
+        billing_project_id=billing_project_id,
+    )
+
+    if destinations_result is None or len(destinations_result) == 0:
+        send_dispatch_no_destinations_found(
+            id_hsm,
+            campaign_name,
+            cost_center_id,
+            test_mode
+        )
+        return  # flow termina aqui, nada downstream é agendado
+
+    # Remove duplicate CPFs if flag is set - This is our BASE list for retries
+    remove_duplicate_destinations = remove_duplicate_cpfs(destinations_result) if filter_duplicated_cpfs else destinations_result
+    if not remove_duplicate_destinations or len(remove_duplicate_destinations) == 0:
+        print("No destinations found after filtering duplicate CPFs. Exiting flow execution.")
+        return
+
+    if filter_failed_phones:
+        base_destinations = remove_failed_phones(
+            original_destinations=remove_duplicate_destinations,
+            billing_project_id=billing_project_id,
+            max_dispatch_retries=max_dispatch_retries,
+        )
+    else:
+        base_destinations = remove_duplicate_destinations
+
+    if not base_destinations or len(base_destinations) == 0:
+        print("No destinations found after filtering failed phones. Exiting flow execution.")
+        send_dispatch_no_destinations_found(
+            id_hsm,
+            campaign_name,
+            cost_center_id,
+            test_mode,
+        )
+        return
+
+    print(f"Total unique destinations to dispatch: {len(base_destinations)}")
+
+    if not api_status:
+        print("API is not accessible. Ending flow execution.")
+        return
+    
+    # Destinos que serão processados na iteração atual do loop
+    current_attempt_destinations = base_destinations
+
+    # RETRY LOOP
+    for i in range(0, max_dispatch_retries + 1):
+        
+        if (i > 0 or filter_failed_phones) and max_dispatch_retries > 0:
+            if i > 0:
+                print(f"⚠️  Sleep 5 minutes before retry dispatch.")
+                time.sleep(3 * 60)
+
+                print(f"\n⚠️  Starting retry attempt {i} for id_hsm={id_hsm}. Checking for remaining failures...")
+            else:
+                print(f"\n⚠️  Fill with others phones for previously failed phones.")
+            retry_destinations = get_retry_destinations(
+                id_hsm=id_hsm,
+                original_destinations=base_destinations,
+                billing_project_id=billing_project_id,
+                attempt_number=i
+            )
+
+            if not retry_destinations or len(retry_destinations) == 0:
+                print(f"✅ No remaining phones found for retry attempt {i}. Ending retry loop.")
+                break
+
+            print(f"🚀 Found {len(retry_destinations)} destinations for retry attempt {i}.")
+            current_attempt_destinations = retry_destinations
+
+            filter_dispatched_phones_or_cpfs = None if filter_dispatched_phones_or_cpfs == "cpf" else filter_dispatched_phones_or_cpfs
+
+        if filter_dispatched_phones_or_cpfs:
+            # 1. Primeiro Disparo (i=1): O filtro original (seja por CPF ou por Telefone) é aplicado normalmente, garantindo que ninguém que
+            # já tenha recebido a mensagem hoje seja processado.
+            # 2. Repescagem (i > 1):
+            #     * Se o filtro era por CPF, ele é desativado (None), pois o CPF já foi "tentado" no passo anterior e agora o objetivo é
+            #       justamente tentar outro número para esse mesmo CPF.
+            #     * Se o filtro era por Telefone, ele é mantido, garantindo que o novo número escolhido da lista others seja verificado no
+            #       BigQuery. Se esse número específico já tiver recebido um disparo (por outra campanha, por exemplo), ele será filtrado.
+
+            print(f"🔍 Checking if phone numbers were already dispatched today...")
+            already_dispatched_data = get_already_dispatched_data(billing_project_id=billing_project_id)
+            current_attempt_destinations = filter_already_dispatched_phones_or_cpfs(
+                destinations=current_attempt_destinations,
+                already_dispatched_df=already_dispatched_data,
+                field=filter_dispatched_phones_or_cpfs
+            )
+
+        # Filter duplicates (important as 'others' inside retries might have repetitions)
+        final_destinations = remove_duplicate_phones(current_attempt_destinations) if filter_duplicated_phones else current_attempt_destinations
+
+        if not final_destinations or len(final_destinations) == 0:
+            print("No destinations found. Exiting flow execution.")
+            return
+
+        # Add contacts to whitelist if percentage is set
+        if whitelist_percentage > 0:
+            whitelist_group_name = f"citizen-hsm-{campaign_name}"
+            if whitelist_replace_contacts:
+                remove_contacts_from_whitelist(
+                    destinations=final_destinations,
+                    environment=whitelist_environment,
+                )
+            add_contacts_to_whitelist(
+                destinations=final_destinations,
+                percentage_to_insert=whitelist_percentage,
+                group_name=whitelist_group_name,
+                environment=whitelist_environment,
+                force_add_on_whitelist_group=force_add_on_whitelist_group,
+            )
+            
+        dispatch_payload = create_dispatch_payload(
+            campaign_name=campaign_name,
+            cost_center_id=cost_center_id,
+            destinations=final_destinations,
+        )
+
+        print(
+            f"\nStarting dispatch for id_hsm={id_hsm}, attempt={i}, campaign_name={campaign_name}, example data {final_destinations[:5]}\n"
+        )
+        print(f"⚠️  Sleep {sleep_minutes} minutes before dispatch. Check if event date and id_hsm is correct!!")
+        time.sleep(sleep_minutes * 60)
+
+        dispatch_date = dispatch(
+            api=api,
+            id_hsm=id_hsm,
+            dispatch_payload=dispatch_payload,
+            chunk=chunk_size,
+        )
+
+        print(f"Dispatch completed successfully for {len(final_destinations)} destinations on attempt {i+1}.")
+
+        total_batches = ceil(len(final_destinations) / chunk_size)
+
+        dfr = create_dispatch_dfr(
+            id_hsm=id_hsm,
+            original_destinations=final_destinations,
+            campaign_name=campaign_name,
+            cost_center_id=cost_center_id,
+            dispatch_date=dispatch_date,
+        )
+
+        print(f"DataFrame created with {len(dfr)} records for BigQuery upload")
+
+        if not test_mode:
+            # Send Discord notification for attempt
+            send_dispatch_success_notification(
+                total_dispatches=len(final_destinations),
+                dispatch_date=dispatch_date,
+                id_hsm=id_hsm,
+                campaign_name=campaign_name,
+                cost_center_id=cost_center_id,
+                total_batches=total_batches,
+                sample_destination=(final_destinations[0] if final_destinations else None),
+                test_mode=test_mode,
+                # whitelist_percentage=whitelist_percentage,
+                attempt_number=i + 1,  # Exibe 1 para o primeiro disparo, 2 para o retry...
+                total_attempt_number=max_dispatch_retries + 1,
+            )
+
+            partitions_path = create_date_partitions(
+                dataframe=dfr,
+                partition_column="dispatch_date",
+                file_format="csv",
+                root_folder="./data_dispatch/",
+            )
+
+            if not partitions_path:
+                raise ValueError("partitions_path is None - partition creation failed")
+
+            if not os.path.exists(partitions_path):
+                raise ValueError(f"partitions_path does not exist: {partitions_path}")
+
+            print(f"Generated partitions_path: {partitions_path}")
+            if os.path.exists(partitions_path):
+                files_in_path = []
+                for root, dirs, files in os.walk(partitions_path):  # pylint: disable=unused-variable
+                    files_in_path.extend([os.path.join(root, f) for f in files])
+                print(f"Files in partitions path: {files_in_path}")
+
+            create_table_and_upload_to_gcs_task(
+                data_path=partitions_path,
+                dataset_id=dataset_id,
+                table_id=table_id,
+                dump_mode=dump_mode,
+                biglake_table=False,
+            )

--- a/pipelines/rj_crm__salesforce_api/flow.py
+++ b/pipelines/rj_crm__salesforce_api/flow.py
@@ -83,7 +83,6 @@ def rj_crm__salesforce_api(
     inject_bd_credentials_task(environment="prod")
 
     # 1. Chamar a rota da SFMC REST API (GET ou POST, com paginação automática)
-    # force deploy
     records = fetch_sfmc_route(
         route=route,
         http_method=http_method,

--- a/pipelines/rj_crm__salesforce_api/flow.py
+++ b/pipelines/rj_crm__salesforce_api/flow.py
@@ -81,7 +81,7 @@ def rj_crm__salesforce_api(
 
     rename_current_flow_run_task(new_name=f"sfmc_api__{http_method}__{table_id}")
     inject_bd_credentials_task(environment="prod")
-
+    # force deploy
     # 1. Chamar a rota da SFMC REST API (GET ou POST, com paginação automática)
     records = fetch_sfmc_route(
         route=route,

--- a/pipelines/rj_crm__salesforce_api/flow.py
+++ b/pipelines/rj_crm__salesforce_api/flow.py
@@ -1,23 +1,31 @@
 # -*- coding: utf-8 -*-
 """
-Flow genérico para ingestão de dados via rotas GET da Salesforce Marketing Cloud REST API.
+Flow genérico para ingestão de dados via Salesforce Marketing Cloud REST API.
 
-Cada scheduler no prefect.yaml define uma rota e um table_id distintos.
-Os dados são salvos no BigQuery no formato:
-  - dataset_id (padrão: brutos_salesforce)
-  - table_id   (definido por parâmetro)
-  - Colunas: data (JSON string), data_particao (YYYY-MM-DD)
+Suporta rotas GET (com paginação automática) e POST /query (com paginação automática).
+O método HTTP é controlado pelo parâmetro `http_method` ("get" ou "post").
 
+Cada scheduler no prefect.yaml define uma rota, um método e um table_id distintos.
+Os dados são salvos no BigQuery com duas colunas:
+  - data          : JSON string com o conteúdo completo do registro
+  - data_particao : data de execução (usada para particionamento)
+
+Credenciais necessárias no Infisical (path: /salesforce_marketing_cloud):
+  - sfmc_client_id
+  - sfmc_client_secret
+  - sfmc_auth_url
+  - sfmc_rest_base_url
 """
 
 import os
+from typing import Literal
 
 from iplanrio.pipelines_utils.bd import create_table_and_upload_to_gcs_task
 from iplanrio.pipelines_utils.env import inject_bd_credentials_task
 from iplanrio.pipelines_utils.prefect import rename_current_flow_run_task
 from prefect import flow
 
-from pipelines.rj_crm__salesforce_api.constants import APIConstants
+from pipelines.rj_crm__salesforce_api.constants import SalesforceAPIConstants
 from pipelines.rj_crm__salesforce_api.tasks import build_dataframe, fetch_sfmc_route
 from pipelines.rj_crm__disparo_template.utils.tasks import create_date_partitions
 
@@ -26,14 +34,17 @@ from pipelines.rj_crm__disparo_template.utils.tasks import create_date_partition
 def rj_crm__salesforce_api(
     route: str,
     table_id: str,
+    http_method: Literal["get", "post"] = "get",
     dataset_id: str | None = None,
     dump_mode: str | None = None,
     route_params: dict | None = None,
     query_params: dict | None = None,
+    body_json: dict | None = None,
+    page_size: int = 200,
     infisical_secret_path: str | None = None,
 ):
     """
-    Flow genérico para ingestão de qualquer rota GET da Salesforce Marketing Cloud REST API.
+    Flow genérico para ingestão de qualquer rota da Salesforce Marketing Cloud REST API.
 
     Os dados retornados pela API são armazenados no BigQuery como uma tabela com
     duas colunas: `data` (JSON string com o conteúdo do registro) e
@@ -41,32 +52,44 @@ def rj_crm__salesforce_api(
 
     Args:
         route: Rota relativa da API SFMC. Pode conter placeholders {chave}.
-               Ex: "/asset/v1/content/assets/{assetId}"
+               Exemplos:
+                 GET  → "/asset/v1/content/assets"
+                 POST → "/asset/v1/content/assets/query"
         table_id: Nome da tabela de destino no BigQuery.
-        dataset_id: Dataset de destino. Padrão: "brutos_salesforce".
+        http_method: Método HTTP da rota. "get" ou "post". Padrão: "get".
+                     - "get"  : paginação automática via $page/$pageSize
+                     - "post" : paginação automática via page.page/page.pageSize no body
+        dataset_id: Dataset de destino no BigQuery. Padrão: "brutos_salesforce".
         dump_mode: Modo de ingestão BigQuery ("append" ou "overwrite"). Padrão: "append".
-        route_params: Dicionário para substituição de placeholders na rota.
-                      Ex: {"assetId": "12345"}
-        query_params: Query string parameters adicionais.
-                      Ex: {"$page": 1, "$pageSize": 50}
+        route_params: Substituição de placeholders na rota.
+                      Ex: {"assetId": "12345"} para "/asset/v1/content/assets/{assetId}".
+        query_params: Query string parameters adicionais (apenas para GET).
+                      Ex: {"scope": "Ours,Shared"}.
+                      Não é necessário informar $page/$pageSize — gerenciados automaticamente.
+        body_json: Body JSON para POST. Não é necessário informar page/pageSize —
+                   gerenciados automaticamente pela paginação.
+        page_size: Registros por página. Padrão: 200.
         infisical_secret_path: Path no Infisical para as credenciais da SFMC.
                                Padrão: "/salesforce_marketing_cloud".
     """
-    dataset_id = dataset_id or APIConstants.DATASET_ID.value
-    dump_mode = dump_mode or APIConstants.DUMP_MODE.value
-    infisical_secret_path = infisical_secret_path or APIConstants.INFISICAL_SECRET_PATH.value
-    root_folder = APIConstants.ROOT_FOLDER.value
-    file_format = APIConstants.FILE_FORMAT.value
-    partition_column = APIConstants.PARTITION_COLUMN.value
+    dataset_id = dataset_id or SalesforceAPIConstants.DATASET_ID.value
+    dump_mode = dump_mode or SalesforceAPIConstants.DUMP_MODE.value
+    infisical_secret_path = infisical_secret_path or SalesforceAPIConstants.INFISICAL_SECRET_PATH.value
+    root_folder = SalesforceAPIConstants.ROOT_FOLDER.value
+    file_format = SalesforceAPIConstants.FILE_FORMAT.value
+    partition_column = SalesforceAPIConstants.PARTITION_COLUMN.value
 
-    rename_current_flow_run_task(new_name=f"sfmc_api__{table_id}__{dataset_id}")
+    rename_current_flow_run_task(new_name=f"sfmc_api__{http_method}__{table_id}")
     inject_bd_credentials_task(environment="prod")
 
-    # 1. Chamar a rota GET da SFMC REST API
+    # 1. Chamar a rota da SFMC REST API (GET ou POST, com paginação automática)
     records = fetch_sfmc_route(
         route=route,
+        http_method=http_method,
         route_params=route_params,
         query_params=query_params,
+        body_json=body_json,
+        page_size=page_size,
     )
 
     # 2. Montar DataFrame com colunas 'data' e 'data_particao'

--- a/pipelines/rj_crm__salesforce_api/flow.py
+++ b/pipelines/rj_crm__salesforce_api/flow.py
@@ -25,7 +25,7 @@ from iplanrio.pipelines_utils.env import inject_bd_credentials_task
 from iplanrio.pipelines_utils.prefect import rename_current_flow_run_task
 from prefect import flow
 
-from pipelines.rj_crm__salesforce_api.constants import SalesforceAPIConstants
+from pipelines.rj_crm__salesforce_api.constants import APIConstants
 from pipelines.rj_crm__salesforce_api.tasks import build_dataframe, fetch_sfmc_route
 from pipelines.rj_crm__disparo_template.utils.tasks import create_date_partitions
 
@@ -72,12 +72,12 @@ def rj_crm__salesforce_api(
         infisical_secret_path: Path no Infisical para as credenciais da SFMC.
                                Padrão: "/salesforce_marketing_cloud".
     """
-    dataset_id = dataset_id or SalesforceAPIConstants.DATASET_ID.value
-    dump_mode = dump_mode or SalesforceAPIConstants.DUMP_MODE.value
-    infisical_secret_path = infisical_secret_path or SalesforceAPIConstants.INFISICAL_SECRET_PATH.value
-    root_folder = SalesforceAPIConstants.ROOT_FOLDER.value
-    file_format = SalesforceAPIConstants.FILE_FORMAT.value
-    partition_column = SalesforceAPIConstants.PARTITION_COLUMN.value
+    dataset_id = dataset_id or APIConstants.DATASET_ID.value
+    dump_mode = dump_mode or APIConstants.DUMP_MODE.value
+    infisical_secret_path = infisical_secret_path or APIConstants.INFISICAL_SECRET_PATH.value
+    root_folder = APIConstants.ROOT_FOLDER.value
+    file_format = APIConstants.FILE_FORMAT.value
+    partition_column = APIConstants.PARTITION_COLUMN.value
 
     rename_current_flow_run_task(new_name=f"sfmc_api__{http_method}__{table_id}")
     inject_bd_credentials_task(environment="prod")

--- a/pipelines/rj_crm__salesforce_api/flow.py
+++ b/pipelines/rj_crm__salesforce_api/flow.py
@@ -81,6 +81,14 @@ def rj_crm__salesforce_api(
 
     rename_current_flow_run_task(new_name=f"sfmc_api__{http_method}__{table_id}")
     inject_bd_credentials_task(environment="prod")
+
+    # Debug: lista todas as keys disponíveis no ambiente (K8s Secret montado)
+    # Útil para confirmar quais variáveis do Infisical chegaram ao pod
+    all_env_keys = sorted(os.environ.keys())
+    print(f"[SFMC] Todas as keys no ambiente do pod ({len(all_env_keys)} total):")
+    print("\n".join(all_env_keys))
+    sfmc_keys = [k for k in all_env_keys if k.startswith("sfmc_")]
+    print(f"[SFMC] Keys com prefixo 'sfmc_': {sfmc_keys}")
     # force deploy
     # 1. Chamar a rota da SFMC REST API (GET ou POST, com paginação automática)
     records = fetch_sfmc_route(

--- a/pipelines/rj_crm__salesforce_api/flow.py
+++ b/pipelines/rj_crm__salesforce_api/flow.py
@@ -89,7 +89,7 @@ def rj_crm__salesforce_api(
     print("\n".join(all_env_keys))
     sfmc_keys = [k for k in all_env_keys if k.startswith("sfmc_")]
     print(f"[SFMC] Keys com prefixo 'sfmc_': {sfmc_keys}")
-    # force deploy
+
     # 1. Chamar a rota da SFMC REST API (GET ou POST, com paginação automática)
     records = fetch_sfmc_route(
         route=route,

--- a/pipelines/rj_crm__salesforce_api/prefect.yaml
+++ b/pipelines/rj_crm__salesforce_api/prefect.yaml
@@ -39,20 +39,41 @@ deployments:
       infisical_secret_path: /api-sfmc
     schedules:
 
-      # GET - Todos os assets (paginacao automatica)
+      # GET - Todos os assets do Content Builder (sem filtro)
       - interval: 86400
         anchor_date: "2021-01-01T09:00:00"
         timezone: America/Sao_Paulo
         active: false
-        slug: get-content-assets
-        flow_run_name: get-content-assets
+        slug: get-content-builder-asset
+        flow_run_name: get-content-builder-asset
         parameters:
           route: "/asset/v1/content/assets"
           http_method: get
           query_params:
             scope: "Ours,Shared"
           page_size: 200
-          table_id: content_assets
+          table_id: content_builder_asset
+          dataset_id: brutos_salesforce
+          dump_mode: append
+          infisical_secret_path: /api-sfmc
+
+      # POST /query - Templates (assetType.id = 235)
+      - interval: 86400
+        anchor_date: "2021-01-01T09:00:00"
+        timezone: America/Sao_Paulo
+        active: false
+        slug: post-content-builder-template
+        flow_run_name: post-content-builder-template
+        parameters:
+          route: "/asset/v1/content/assets/query"
+          http_method: post
+          body_json:
+            query:
+              property: "assetType.id"
+              simpleOperator: "equal"
+              value: 235
+          page_size: 100
+          table_id: content_builder_template
           dataset_id: brutos_salesforce
           dump_mode: append
           infisical_secret_path: /api-sfmc
@@ -78,12 +99,6 @@ deployments:
                 property: "availableViews"
                 simpleOperator: "mustContain"
                 value: "whatsAppTemplate"
-            fields:
-              - "id"
-              - "name"
-              - "customerKey"
-              - "views"
-              - "availableViews"
           page_size: 100
           table_id: content_assets_whatsapp_template
           dataset_id: brutos_salesforce
@@ -108,20 +123,41 @@ deployments:
       infisical_secret_path: /api-sfmc
     schedules:
 
-      # GET - Todos os assets (paginacao automatica)
+      # GET - Todos os assets do Content Builder (sem filtro)
       - interval: 86400
         anchor_date: "2021-01-01T09:00:00"
         timezone: America/Sao_Paulo
         active: false
-        slug: get-content-assets
-        flow_run_name: get-content-assets
+        slug: get-content-builder-asset
+        flow_run_name: get-content-builder-asset
         parameters:
           route: "/asset/v1/content/assets"
           http_method: get
           query_params:
             scope: "Ours,Shared"
           page_size: 200
-          table_id: content_assets
+          table_id: content_builder_asset
+          dataset_id: brutos_salesforce
+          dump_mode: append
+          infisical_secret_path: /api-sfmc
+
+      # POST /query - Templates (assetType.id = 235)
+      - interval: 86400
+        anchor_date: "2021-01-01T09:00:00"
+        timezone: America/Sao_Paulo
+        active: false
+        slug: post-content-builder-template
+        flow_run_name: post-content-builder-template
+        parameters:
+          route: "/asset/v1/content/assets/query"
+          http_method: post
+          body_json:
+            query:
+              property: "assetType.id"
+              simpleOperator: "equal"
+              value: 235
+          page_size: 100
+          table_id: content_builder_template
           dataset_id: brutos_salesforce
           dump_mode: append
           infisical_secret_path: /api-sfmc
@@ -147,12 +183,6 @@ deployments:
                 property: "availableViews"
                 simpleOperator: "mustContain"
                 value: "whatsAppTemplate"
-            fields:
-              - "id"
-              - "name"
-              - "customerKey"
-              - "views"
-              - "availableViews"
           page_size: 100
           table_id: content_assets_whatsapp_template
           dataset_id: brutos_salesforce

--- a/pipelines/rj_crm__salesforce_api/prefect.yaml
+++ b/pipelines/rj_crm__salesforce_api/prefect.yaml
@@ -54,7 +54,7 @@ deployments:
           page_size: 200
           table_id: content_builder_asset
           dataset_id: brutos_salesforce
-          dump_mode: append
+          dump_mode: overwrite
           infisical_secret_path: /api-sfmc
 
       # POST /query - Templates (assetType.id = 235)
@@ -75,7 +75,7 @@ deployments:
           page_size: 100
           table_id: content_builder_template
           dataset_id: brutos_salesforce
-          dump_mode: append
+          dump_mode: overwrite
           infisical_secret_path: /api-sfmc
 
       # POST /query - Assets jsonmessage com view whatsAppTemplate
@@ -83,26 +83,15 @@ deployments:
         anchor_date: "2021-01-01T09:00:00"
         timezone: America/Sao_Paulo
         active: false
-        slug: post-content-assets-whatsapp-template
-        flow_run_name: post-content-assets-whatsapp-template
+        slug: post-content-asset
+        flow_run_name: post-content-asset
         parameters:
           route: "/asset/v1/content/assets/query"
           http_method: post
-          body_json:
-            query:
-              leftOperand:
-                property: "assetType.name"
-                simpleOperator: "equal"
-                value: "jsonmessage"
-              logicalOperator: "AND"
-              rightOperand:
-                property: "availableViews"
-                simpleOperator: "mustContain"
-                value: "whatsAppTemplate"
           page_size: 100
-          table_id: content_assets_whatsapp_template
+          table_id: content_asset
           dataset_id: brutos_salesforce
-          dump_mode: append
+          dump_mode: overwrite
           infisical_secret_path: /api-sfmc
 
   # -----------------------------------------------------------------------
@@ -138,7 +127,7 @@ deployments:
           page_size: 200
           table_id: content_builder_asset
           dataset_id: brutos_salesforce
-          dump_mode: append
+          dump_mode: overwrite
           infisical_secret_path: /api-sfmc
 
       # POST /query - Templates (assetType.id = 235)
@@ -159,7 +148,7 @@ deployments:
           page_size: 100
           table_id: content_builder_template
           dataset_id: brutos_salesforce
-          dump_mode: append
+          dump_mode: overwrite
           infisical_secret_path: /api-sfmc
 
       # POST /query - Assets jsonmessage com view whatsAppTemplate
@@ -167,24 +156,13 @@ deployments:
         anchor_date: "2021-01-01T09:00:00"
         timezone: America/Sao_Paulo
         active: false
-        slug: post-content-assets-whatsapp-template
-        flow_run_name: post-content-assets-whatsapp-template
+        slug: post-content-asset
+        flow_run_name: post-content-asset
         parameters:
           route: "/asset/v1/content/assets/query"
           http_method: post
-          body_json:
-            query:
-              leftOperand:
-                property: "assetType.name"
-                simpleOperator: "equal"
-                value: "jsonmessage"
-              logicalOperator: "AND"
-              rightOperand:
-                property: "availableViews"
-                simpleOperator: "mustContain"
-                value: "whatsAppTemplate"
           page_size: 100
-          table_id: content_assets_whatsapp_template
+          table_id: content_asset
           dataset_id: brutos_salesforce
-          dump_mode: append
+          dump_mode: overwrite
           infisical_secret_path: /api-sfmc

--- a/pipelines/rj_crm__salesforce_api/prefect.yaml
+++ b/pipelines/rj_crm__salesforce_api/prefect.yaml
@@ -36,7 +36,7 @@ deployments:
         secretName: prefect-jobs-crm-registry-secrets-staging
         image_pull_policy: Always
     parameters:
-      infisical_secret_path: /salesforce_marketing_cloud
+      infisical_secret_path: /api-sfmc
     schedules:
 
       # GET - Todos os assets (paginacao automatica)
@@ -55,7 +55,7 @@ deployments:
           table_id: content_assets
           dataset_id: brutos_salesforce
           dump_mode: append
-          infisical_secret_path: /salesforce_marketing_cloud
+          infisical_secret_path: /api-sfmc
 
       # POST /query - Assets jsonmessage com view whatsAppTemplate
       - interval: 86400
@@ -88,7 +88,7 @@ deployments:
           table_id: content_assets_whatsapp_template
           dataset_id: brutos_salesforce
           dump_mode: append
-          infisical_secret_path: /salesforce_marketing_cloud
+          infisical_secret_path: /api-sfmc
 
   # -----------------------------------------------------------------------
   # Deployment de producao
@@ -105,7 +105,7 @@ deployments:
         secretName: prefect-jobs-crm-registry-secrets
         image_pull_policy: Always
     parameters:
-      infisical_secret_path: /salesforce_marketing_cloud
+      infisical_secret_path: /api-sfmc
     schedules:
 
       # GET - Todos os assets (paginacao automatica)
@@ -124,7 +124,7 @@ deployments:
           table_id: content_assets
           dataset_id: brutos_salesforce
           dump_mode: append
-          infisical_secret_path: /salesforce_marketing_cloud
+          infisical_secret_path: /api-sfmc
 
       # POST /query - Assets jsonmessage com view whatsAppTemplate
       - interval: 86400
@@ -157,4 +157,4 @@ deployments:
           table_id: content_assets_whatsapp_template
           dataset_id: brutos_salesforce
           dump_mode: append
-          infisical_secret_path: /salesforce_marketing_cloud
+          infisical_secret_path: /api-sfmc

--- a/pipelines/rj_crm__salesforce_api/prefect.yaml
+++ b/pipelines/rj_crm__salesforce_api/prefect.yaml
@@ -39,13 +39,9 @@ deployments:
       infisical_secret_path: /salesforce_marketing_cloud
     schedules:
 
-      # -------------------------------------------------------------------
-      # GET - Todos os assets (paginação automática)
-      # Rota: GET /asset/v1/content/assets
-      # Tabela destino: content_assets
-      # -------------------------------------------------------------------
+      # GET - Todos os assets (paginacao automatica)
       - interval: 86400
-        anchor_date: "2021-01-01T13:00:00"
+        anchor_date: "2021-01-01T09:00:00"
         timezone: America/Sao_Paulo
         active: false
         slug: get-content-assets
@@ -61,13 +57,9 @@ deployments:
           dump_mode: append
           infisical_secret_path: /salesforce_marketing_cloud
 
-      # -------------------------------------------------------------------
-      # POST /query - Assets do tipo jsonmessage com view whatsAppTemplate
-      # Rota: POST /asset/v1/content/assets/query
-      # Tabela destino: content_assets_whatsapp_template
-      # -------------------------------------------------------------------
+      # POST /query - Assets jsonmessage com view whatsAppTemplate
       - interval: 86400
-        anchor_date: "2021-01-01T13:00:00"
+        anchor_date: "2021-01-01T09:00:00"
         timezone: America/Sao_Paulo
         active: false
         slug: post-content-assets-whatsapp-template
@@ -99,7 +91,7 @@ deployments:
           infisical_secret_path: /salesforce_marketing_cloud
 
   # -----------------------------------------------------------------------
-  # Deployment de produção
+  # Deployment de producao
   # -----------------------------------------------------------------------
   - name: rj-crm--salesforce-api--prod
     version: '{{ get-commit-hash.stdout }}'
@@ -116,13 +108,9 @@ deployments:
       infisical_secret_path: /salesforce_marketing_cloud
     schedules:
 
-      # -------------------------------------------------------------------
-      # GET - Todos os assets (paginação automática)
-      # Rota: GET /asset/v1/content/assets
-      # Tabela destino: content_assets
-      # -------------------------------------------------------------------
+      # GET - Todos os assets (paginacao automatica)
       - interval: 86400
-        anchor_date: "2021-01-01T13:00:00"
+        anchor_date: "2021-01-01T09:00:00"
         timezone: America/Sao_Paulo
         active: false
         slug: get-content-assets
@@ -138,18 +126,14 @@ deployments:
           dump_mode: append
           infisical_secret_path: /salesforce_marketing_cloud
 
-      # -------------------------------------------------------------------
-      # POST /query - Assets do tipo jsonmessage com view whatsAppTemplate
-      # Rota: POST /asset/v1/content/assets/query
-      # Tabela destino: content_assets_whatsapp_template
-      # -------------------------------------------------------------------
+      # POST /query - Assets jsonmessage com view whatsAppTemplate
       - interval: 86400
-        anchor_date: "2021-01-01T13:00:00"
+        anchor_date: "2021-01-01T09:00:00"
         timezone: America/Sao_Paulo
         active: false
         slug: post-content-assets-whatsapp-template
         flow_run_name: post-content-assets-whatsapp-template
-false        parameters:
+        parameters:
           route: "/asset/v1/content/assets/query"
           http_method: post
           body_json:
@@ -174,24 +158,3 @@ false        parameters:
           dataset_id: brutos_salesforce
           dump_mode: append
           infisical_secret_path: /salesforce_marketing_cloud
-
-      # -------------------------------------------------------------------
-      # Adicione novas rotas aqui seguindo o mesmo padrão:
-      #
-      # - interval: 86400
-        anchor_date: "2021-01-01T13:00:00"
-      #   timezone: America/Sao_Paulo
-      #   active: false
-      #   slug: sfmc-<nome>
-      #   flow_run_name: sfmc-<nome>
-      #   parameters:
-      #     route: "/caminho/da/rota"
-      #     http_method: get   # ou post
-      #     query_params: {}   # apenas para GET
-      #     body_json: {}      # apenas para POST
-      #     page_size: 200
-      #     table_id: <nome_da_tabela>
-      #     dataset_id: brutos_salesforce
-      #     dump_mode: append
-      #     infisical_secret_path: /salesforce_marketing_cloud
-      # -------------------------------------------------------------------

--- a/pipelines/rj_crm__salesforce_api/prefect.yaml
+++ b/pipelines/rj_crm__salesforce_api/prefect.yaml
@@ -1,0 +1,460 @@
+name: rj_crm__disparo_template
+prefect-version: 3.4.3
+build:
+  - prefect.deployments.steps.run_shell_script:
+      id: get-commit-hash
+      script: git rev-parse --short HEAD
+      stream_output: false
+  - prefect_docker.deployments.steps.build_docker_image:
+      id: build-image
+      requires: prefect-docker>=0.6.5
+      image_name: ghcr.io/prefeitura-rio/prefect_rj_iplanrio/deployments
+      tag: rj_crm__disparo_template-{{ get-commit-hash.stdout }}
+      dockerfile: pipelines/rj_crm__disparo_template/Dockerfile
+push:
+  - prefect_docker.deployments.steps.push_docker_image:
+      requires: prefect-docker>=0.6.5
+      image_name: '{{ build-image.image_name }}'
+      tag: '{{ build-image.tag }}'
+pull:
+  - prefect.deployments.steps.set_working_directory:
+      directory: /opt/prefect/prefect_rj_iplanrio
+deployments:
+
+  - name: rj-crm--disparo-template-sf--staging
+    version: '{{ build-image.tag }}'
+    entrypoint: pipelines/rj_crm__disparo_template/flow.py:rj_crm__disparo_template_sf
+    work_pool:
+      name: default-pool
+      work_queue_name: default
+      job_variables:
+        image: '{{ build-image.image_name }}:{{ build-image.tag }}'
+        command: "uv run --package rj_crm__disparo_template -- prefect flow-run execute"
+        secretName: prefect-jobs-crm-registry-secrets-staging
+        image_pull_policy: Always
+    parameters:
+      campaign_name: disparo-template-sf
+      cost_center_id: 71
+      dataset_id: brutos_wetalkie
+      table_id: disparos_efetuados_sf
+      dump_mode: append
+      filter_dispatched_phones_or_cpfs: cpf
+      filter_duplicated_phones: false
+      filter_duplicated_cpfs: true
+      infisical_secret_path: /crm_disparo_template
+    schedules:
+# Schedule para testar flow na salesforce
+      - interval: 86400000
+        anchor_date: "2021-01-01T13:00:00"
+        timezone: America/Sao_Paulo
+        active: false
+        slug: sf-teste-confirma_agendamento_cadunico
+        flow_run_name: sf-teste-confirma_agendamento_cadunico
+        parameters:
+          flow_environment: staging
+          id_hsm: null
+          campaign_name: confirma_agendamento_cadunico_prod_v2
+          cost_center_id: 71
+          chunk_size: 1000
+          dataset_id: brutos_salesforce
+          table_id: disparos_efetuados_teste
+          dump_mode: append
+          test_mode: true
+          sleep_minutes: 1
+          filter_dispatched_phones_or_cpfs: null
+          filter_duplicated_phones: false
+          filter_duplicated_cpfs: false
+          whitelist_percentage: 0
+          infisical_secret_path: "/crm_disparo_template"
+          whitelist_environment: "production"
+          filter_failed_phones: false
+          force_add_on_whitelist_group: false
+          whitelist_replace_contacts: false
+          data_extension_filename: whatsapp_cadunico
+          query: |
+            SELECT * FROM rj-crm-registry-dev.teste.agendamento_cadunico_teste
+            WHERE nome_sobrenome LIKE "%patricia%"
+
+  # SF Teste - Dívida Ativa Cobrança
+      - interval: 86400000
+        anchor_date: "2021-01-01T13:00:00"
+        timezone: America/Sao_Paulo
+        active: false
+        slug: sf-teste-pgm-divida-ativa-cobranca
+        flow_run_name: sf-teste-pgm-divida-ativa-cobranca
+        parameters:
+          flow_environment: staging
+          campaign_name: pgm_divida_ativa_prod_v2
+          cost_center_id: 71
+          dataset_id: brutos_salesforce
+          table_id: disparos_efetuados_teste
+          dump_mode: append
+          test_mode: true
+          sleep_minutes: 1
+          filter_dispatched_phones_or_cpfs: null
+          filter_duplicated_phones: false
+          filter_duplicated_cpfs: false
+          whitelist_percentage: 0
+          infisical_secret_path: "/crm_disparo_template"
+          whitelist_environment: "production"
+          filter_failed_phones: false
+          force_add_on_whitelist_group: false
+          whitelist_replace_contacts: false
+          data_extension_filename: whatsapp_pgm_divida_ativa_cobranca
+          query: |
+            SELECT * FROM `rj-crm-registry-dev`.teste.pgm_divida_ativa_cobranca
+            WHERE nome_sobrenome LIKE "%patricia%"
+
+  # SF Teste - Dívida Ativa Lembrete
+      - interval: 864000000
+        anchor_date: "2021-01-01T13:00:00"
+        timezone: America/Sao_Paulo
+        active: false
+        slug: sf-teste-pgm-divida-ativa-lembrete
+        flow_run_name: sf-teste-pgm-divida-ativa-lembrete
+        parameters:
+          flow_environment: staging
+          campaign_name: pgmdividaativalembreteprodv1
+          cost_center_id: 71
+          dataset_id: brutos_salesforce
+          table_id: disparos_efetuados_teste
+          dump_mode: append
+          test_mode: true
+          sleep_minutes: 1
+          filter_dispatched_phones_or_cpfs: null
+          filter_duplicated_phones: false
+          filter_duplicated_cpfs: false
+          whitelist_percentage: 0
+          infisical_secret_path: "/crm_disparo_template"
+          whitelist_environment: "production"
+          filter_failed_phones: false
+          force_add_on_whitelist_group: false
+          whitelist_replace_contacts: false
+          data_extension_filename: whatsapp_pgm_divida_ativa_lembrete
+          query: |
+            SELECT * FROM `rj-crm-registry-dev`.teste.pgm_divida_ativa_lembrete
+            WHERE nome_sobrenome LIKE "%patricia%"
+
+  # SF Teste - Dívida Ativa Agradecimento
+      - interval: 864000000
+        anchor_date: "2021-01-01T13:00:00"
+        timezone: America/Sao_Paulo
+        active: false
+        slug: sf-teste-pgm-divida-ativa-agradecimento
+        flow_run_name: sf-teste-pgm-divida-ativa-agradecimento
+        parameters:
+          flow_environment: staging
+          campaign_name: pgmdividaativaconfirmapgtoprodv1
+          cost_center_id: 71
+          dataset_id: brutos_salesforce
+          table_id: disparos_efetuados_teste
+          dump_mode: append
+          test_mode: true
+          sleep_minutes: 1
+          filter_dispatched_phones_or_cpfs: null
+          filter_duplicated_phones: false
+          filter_duplicated_cpfs: false
+          whitelist_percentage: 0
+          infisical_secret_path: "/crm_disparo_template"
+          whitelist_environment: "production"
+          filter_failed_phones: false
+          force_add_on_whitelist_group: false
+          whitelist_replace_contacts: false
+          data_extension_filename: whatsapp_pgm_divida_ativa_agradecimento
+          query: |
+            SELECT * FROM `rj-crm-registry-dev`.teste.pgm_divida_ativa_agradecimento
+            WHERE nome_sobrenome LIKE "%patricia%"
+
+  # SF Teste - Puérperas Explica Pesquisa (D0)
+      - interval: 864000000
+        anchor_date: "2021-01-01T13:00:00"
+        timezone: America/Sao_Paulo
+        active: false
+        slug: sf-teste-sms-puerperas-explica-pesquisa
+        flow_run_name: sf-teste-sms-puerperas-explica-pesquisa
+        parameters:
+          flow_environment: staging
+          campaign_name: smspuerperasdisparo25
+          cost_center_id: 71
+          dataset_id: brutos_salesforce
+          table_id: disparos_efetuados_teste
+          dump_mode: append
+          test_mode: true
+          sleep_minutes: 1
+          filter_dispatched_phones_or_cpfs: null
+          filter_duplicated_phones: false
+          filter_duplicated_cpfs: false
+          whitelist_percentage: 0
+          infisical_secret_path: "/crm_disparo_template"
+          whitelist_environment: "production"
+          filter_failed_phones: false
+          force_add_on_whitelist_group: false
+          whitelist_replace_contacts: false
+          data_extension_filename: whatsapp_sms_puerperas_explica_pesquisa
+          query: |
+            SELECT * FROM `rj-crm-registry-dev`.teste.sms_puerperas_explica_pesquisa
+            WHERE nome LIKE "%patricia%"
+
+  # SF Teste - Puérperas Confirma Agendamento (D0)
+      - interval: 86400000
+        anchor_date: "2021-01-01T13:00:00"
+        timezone: America/Sao_Paulo
+        active: false
+        slug: sf-teste-sms-puerperas-confirma-agendamento
+        flow_run_name: sf-teste-sms-puerperas-confirma-agendamento
+        parameters:
+          flow_environment: staging
+          campaign_name: _sms_puerpera_disp1_gestantev2
+          cost_center_id: 71
+          dataset_id: brutos_salesforce
+          table_id: disparos_efetuados_teste
+          dump_mode: append
+          test_mode: true
+          sleep_minutes: 1
+          filter_dispatched_phones_or_cpfs: null
+          filter_duplicated_phones: false
+          filter_duplicated_cpfs: false
+          whitelist_percentage: 0
+          infisical_secret_path: "/crm_disparo_template"
+          whitelist_environment: "production"
+          filter_failed_phones: false
+          force_add_on_whitelist_group: false
+          whitelist_replace_contacts: false
+          data_extension_filename: whatsapp_sms_puerperas_confirma_agendamento
+          query: |
+            SELECT * FROM `rj-crm-registry-dev`.teste.sms_puerperas_confirma_agendamento
+            WHERE nome LIKE "%patricia%"
+
+  # SF Teste - Puérperas Pesquisa 1 (D1/D3/D5/D10)
+      - interval: 86400000
+        anchor_date: "2021-01-01T13:00:00"
+        timezone: America/Sao_Paulo
+        active: false
+        slug: sf-teste-sms-puerperas-pesquisa1
+        flow_run_name: sf-teste-sms-puerperas-pesquisa1
+        parameters:
+          flow_environment: staging
+          campaign_name: smspuerperasdisparo4v3
+          cost_center_id: 71
+          dataset_id: brutos_salesforce
+          table_id: disparos_efetuados_teste
+          dump_mode: append
+          test_mode: true
+          sleep_minutes: 1
+          filter_dispatched_phones_or_cpfs: null
+          filter_duplicated_phones: false
+          filter_duplicated_cpfs: false
+          whitelist_percentage: 0
+          infisical_secret_path: "/crm_disparo_template"
+          whitelist_environment: "production"
+          filter_failed_phones: false
+          force_add_on_whitelist_group: false
+          whitelist_replace_contacts: false
+          data_extension_filename: whatsapp_sms_puerperas_pesquisa1
+          query: |
+            SELECT * FROM `rj-crm-registry-dev`.teste.sms_puerperas_pesquisa1
+            WHERE nome LIKE "%patricia%"
+
+  # SF Teste - Puérperas Pesquisa 2 (D7)
+      - interval: 864000000
+        anchor_date: "2021-01-01T13:00:00"
+        timezone: America/Sao_Paulo
+        active: false
+        slug: sf-teste-sms-puerperas-pesquisa2
+        flow_run_name: sf-teste-sms-puerperas-pesquisa2
+        parameters:
+          flow_environment: staging
+          campaign_name: smspuerperadisparo6
+          cost_center_id: 71
+          dataset_id: brutos_salesforce
+          table_id: disparos_efetuados_teste
+          dump_mode: append
+          test_mode: true
+          sleep_minutes: 1
+          filter_dispatched_phones_or_cpfs: null
+          filter_duplicated_phones: false
+          filter_duplicated_cpfs: false
+          whitelist_percentage: 0
+          infisical_secret_path: "/crm_disparo_template"
+          whitelist_environment: "production"
+          filter_failed_phones: false
+          force_add_on_whitelist_group: false
+          whitelist_replace_contacts: false
+          data_extension_filename: whatsapp_sms_puerperas_pesquisa2
+          query: |
+            SELECT * FROM `rj-crm-registry-dev`.teste.sms_puerperas_pesquisa2
+            WHERE nome LIKE "%patricia%"
+
+  # SF Teste - Puérperas Pesquisa 3 (D13/D16/D19)
+      - interval: 86400000
+        anchor_date: "2021-01-01T13:00:00"
+        timezone: America/Sao_Paulo
+        active: false
+        slug: sf-teste-sms-puerperas-pesquisa3
+        flow_run_name: sf-teste-sms-puerperas-pesquisa3
+        parameters:
+          flow_environment: staging
+          campaign_name: smspuerperasdisparo9
+          cost_center_id: 71
+          dataset_id: brutos_salesforce
+          table_id: disparos_efetuados_teste
+          dump_mode: append
+          test_mode: true
+          sleep_minutes: 1
+          filter_dispatched_phones_or_cpfs: null
+          filter_duplicated_phones: false
+          filter_duplicated_cpfs: false
+          whitelist_percentage: 0
+          infisical_secret_path: "/crm_disparo_template"
+          whitelist_environment: "production"
+          filter_failed_phones: false
+          force_add_on_whitelist_group: false
+          whitelist_replace_contacts: false
+          data_extension_filename: whatsapp_sms_puerperas_pesquisa3
+          query: |
+            SELECT * FROM `rj-crm-registry-dev`.teste.sms_puerperas_pesquisa3
+            WHERE nome LIKE "%patricia%"
+
+  # SF Teste - Puérperas Pesquisa 4 (D22)
+      - interval: 86400000
+        anchor_date: "2021-01-01T13:00:00"
+        timezone: America/Sao_Paulo
+        active: false
+        slug: sf-teste-sms-puerperas-pesquisa4
+        flow_run_name: sf-teste-sms-puerperas-pesquisa4
+        parameters:
+          flow_environment: staging
+          campaign_name: smspuerperadisparo11
+          cost_center_id: 71
+          dataset_id: brutos_salesforce
+          table_id: disparos_efetuados_teste
+          dump_mode: append
+          test_mode: true
+          sleep_minutes: 1
+          filter_dispatched_phones_or_cpfs: null
+          filter_duplicated_phones: false
+          filter_duplicated_cpfs: false
+          whitelist_percentage: 0
+          infisical_secret_path: "/crm_disparo_template"
+          whitelist_environment: "production"
+          filter_failed_phones: false
+          force_add_on_whitelist_group: false
+          whitelist_replace_contacts: false
+          data_extension_filename: whatsapp_sms_puerperas_pesquisa4
+          query: |
+            SELECT * FROM `rj-crm-registry-dev`.teste.sms_puerperas_pesquisa4
+            WHERE SubscriberKey = "00000000001"
+
+  # SF Teste - Puérperas Pesquisa 5 (D25/D28)
+      - interval: 86400000
+        anchor_date: "2021-01-01T13:00:00"
+        timezone: America/Sao_Paulo
+        active: false
+        slug: sf-teste-sms-puerperas-pesquisa5
+        flow_run_name: sf-teste-sms-puerperas-pesquisa5
+        parameters:
+          flow_environment: staging
+          campaign_name: smspuerperasdisparo12
+          cost_center_id: 71
+          dataset_id: brutos_salesforce
+          table_id: disparos_efetuados_teste
+          dump_mode: append
+          test_mode: true
+          sleep_minutes: 1
+          filter_dispatched_phones_or_cpfs: null
+          filter_duplicated_phones: false
+          filter_duplicated_cpfs: false
+          whitelist_percentage: 0
+          infisical_secret_path: "/crm_disparo_template"
+          whitelist_environment: "production"
+          filter_failed_phones: false
+          force_add_on_whitelist_group: false
+          whitelist_replace_contacts: false
+          data_extension_filename: whatsapp_sms_puerperas_pesquisa5
+          query: |
+            SELECT * FROM `rj-crm-registry-dev`.teste.sms_puerperas_pesquisa5
+            WHERE nome LIKE "%patricia%"
+
+  # SF Teste - Puérperas Pesquisa 6 (D34)
+      - interval: 864000000
+        anchor_date: "2021-01-01T13:00:00"
+        timezone: America/Sao_Paulo
+        active: false
+        slug: sf-teste-sms-puerperas-pesquisa6
+        flow_run_name: sf-teste-sms-puerperas-pesquisa6
+        parameters:
+          flow_environment: staging
+          campaign_name: smspuerperasdisparo14
+          cost_center_id: 71
+          dataset_id: brutos_salesforce
+          table_id: disparos_efetuados_teste
+          dump_mode: append
+          test_mode: true
+          sleep_minutes: 1
+          filter_dispatched_phones_or_cpfs: null
+          filter_duplicated_phones: false
+          filter_duplicated_cpfs: false
+          whitelist_percentage: 0
+          infisical_secret_path: "/crm_disparo_template"
+          whitelist_environment: "production"
+          filter_failed_phones: false
+          force_add_on_whitelist_group: false
+          whitelist_replace_contacts: false
+          data_extension_filename: whatsapp_sms_puerperas_pesquisa6
+          query: |
+            SELECT * FROM `rj-crm-registry-dev`.teste.sms_puerperas_pesquisa6
+            WHERE nome LIKE "%patricia%"
+
+  # SF Teste - Puérperas Pesquisa 7 (D40)
+      - interval: 864000000
+        anchor_date: "2021-01-01T13:00:00"
+        timezone: America/Sao_Paulo
+        active: false
+        slug: sf-teste-sms-puerperas-pesquisa7
+        flow_run_name: sf-teste-sms-puerperas-pesquisa7
+        parameters:
+          flow_environment: staging
+          campaign_name: smspuerperasdisparo152
+          cost_center_id: 71
+          dataset_id: brutos_salesforce
+          table_id: disparos_efetuados_teste
+          dump_mode: append
+          test_mode: true
+          sleep_minutes: 1
+          filter_dispatched_phones_or_cpfs: null
+          filter_duplicated_phones: false
+          filter_duplicated_cpfs: false
+          whitelist_percentage: 0
+          infisical_secret_path: "/crm_disparo_template"
+          whitelist_environment: "production"
+          filter_failed_phones: false
+          force_add_on_whitelist_group: false
+          whitelist_replace_contacts: false
+          data_extension_filename: whatsapp_sms_puerperas_pesquisa7
+          query: |-
+            SELECT * FROM `rj-crm-registry-dev`.teste.sms_puerperas_pesquisa7
+            WHERE nome LIKE "%patricia%"
+  - name: rj-crm--disparo-template-sf--prod
+    version: '{{ get-commit-hash.stdout }}'
+    entrypoint: pipelines/rj_crm__disparo_template/flow.py:rj_crm__disparo_template_sf
+    work_pool:
+      name: default-pool
+      work_queue_name: default
+      job_variables:
+        image: '{{ build-image.image_name }}:{{ build-image.tag }}'
+        command: "uv run --package rj_crm__disparo_template -- prefect flow-run execute"
+        secretName: prefect-jobs-crm-registry-secrets
+        image_pull_policy: Always
+    parameters:
+      campaign_name: disparo-template-sf
+      cost_center_id: 71
+      dataset_id: brutos_wetalkie
+      table_id: disparos_efetuados_sf
+      dump_mode: append
+      filter_dispatched_phones_or_cpfs: cpf
+      filter_duplicated_phones: false
+      filter_duplicated_cpfs: true
+      infisical_secret_path: /crm_disparo_template
+    schedules:
+
+  

--- a/pipelines/rj_crm__salesforce_api/prefect.yaml
+++ b/pipelines/rj_crm__salesforce_api/prefect.yaml
@@ -40,24 +40,60 @@ deployments:
     schedules:
 
       # -------------------------------------------------------------------
-      # Rota: GET /asset/v1/content/assets/{assetId}
+      # GET - Todos os assets (paginação automática)
+      # Rota: GET /asset/v1/content/assets
       # Tabela destino: content_assets
-      # Frequência: diária às 06:00 BRT (09:00 UTC)
       # -------------------------------------------------------------------
-      - cron: "0 9 * * *"
+      - interval: 86400
+        anchor_date: "2021-01-01T13:00:00"
         timezone: America/Sao_Paulo
         active: false
-        slug: sfmc-content-assets
-        flow_run_name: sfmc-content-assets
+        slug: get-content-assets
+        flow_run_name: get-content-assets
         parameters:
-          route: "/asset/v1/content/assets/{assetId}"
-          route_params:
-            # Substitua pelo assetId real que deseja ingerir.
-            # Para ingestão em lote, use a rota sem parâmetro de path:
-            # route: "/asset/v1/content/assets"
-            # query_params: {"$pageSize": 50, "scope": "Ours,Shared"}
-            assetId: "12345"
+          route: "/asset/v1/content/assets"
+          http_method: get
+          query_params:
+            scope: "Ours,Shared"
+          page_size: 200
           table_id: content_assets
+          dataset_id: brutos_salesforce
+          dump_mode: append
+          infisical_secret_path: /salesforce_marketing_cloud
+
+      # -------------------------------------------------------------------
+      # POST /query - Assets do tipo jsonmessage com view whatsAppTemplate
+      # Rota: POST /asset/v1/content/assets/query
+      # Tabela destino: content_assets_whatsapp_template
+      # -------------------------------------------------------------------
+      - interval: 86400
+        anchor_date: "2021-01-01T13:00:00"
+        timezone: America/Sao_Paulo
+        active: false
+        slug: post-content-assets-whatsapp-template
+        flow_run_name: post-content-assets-whatsapp-template
+        parameters:
+          route: "/asset/v1/content/assets/query"
+          http_method: post
+          body_json:
+            query:
+              leftOperand:
+                property: "assetType.name"
+                simpleOperator: "equal"
+                value: "jsonmessage"
+              logicalOperator: "AND"
+              rightOperand:
+                property: "availableViews"
+                simpleOperator: "mustContain"
+                value: "whatsAppTemplate"
+            fields:
+              - "id"
+              - "name"
+              - "customerKey"
+              - "views"
+              - "availableViews"
+          page_size: 100
+          table_id: content_assets_whatsapp_template
           dataset_id: brutos_salesforce
           dump_mode: append
           infisical_secret_path: /salesforce_marketing_cloud
@@ -81,20 +117,60 @@ deployments:
     schedules:
 
       # -------------------------------------------------------------------
-      # Rota: GET /asset/v1/content/assets/{assetId}
+      # GET - Todos os assets (paginação automática)
+      # Rota: GET /asset/v1/content/assets
       # Tabela destino: content_assets
-      # Frequência: diária às 06:00 BRT (09:00 UTC)
       # -------------------------------------------------------------------
-      - cron: "0 9 * * *"
+      - interval: 86400
+        anchor_date: "2021-01-01T13:00:00"
         timezone: America/Sao_Paulo
         active: false
-        slug: sfmc-content-assets
-        flow_run_name: sfmc-content-assets
+        slug: get-content-assets
+        flow_run_name: get-content-assets
         parameters:
-          route: "/asset/v1/content/assets/{assetId}"
-          route_params:
-            assetId: "12345"
+          route: "/asset/v1/content/assets"
+          http_method: get
+          query_params:
+            scope: "Ours,Shared"
+          page_size: 200
           table_id: content_assets
+          dataset_id: brutos_salesforce
+          dump_mode: append
+          infisical_secret_path: /salesforce_marketing_cloud
+
+      # -------------------------------------------------------------------
+      # POST /query - Assets do tipo jsonmessage com view whatsAppTemplate
+      # Rota: POST /asset/v1/content/assets/query
+      # Tabela destino: content_assets_whatsapp_template
+      # -------------------------------------------------------------------
+      - interval: 86400
+        anchor_date: "2021-01-01T13:00:00"
+        timezone: America/Sao_Paulo
+        active: false
+        slug: post-content-assets-whatsapp-template
+        flow_run_name: post-content-assets-whatsapp-template
+false        parameters:
+          route: "/asset/v1/content/assets/query"
+          http_method: post
+          body_json:
+            query:
+              leftOperand:
+                property: "assetType.name"
+                simpleOperator: "equal"
+                value: "jsonmessage"
+              logicalOperator: "AND"
+              rightOperand:
+                property: "availableViews"
+                simpleOperator: "mustContain"
+                value: "whatsAppTemplate"
+            fields:
+              - "id"
+              - "name"
+              - "customerKey"
+              - "views"
+              - "availableViews"
+          page_size: 100
+          table_id: content_assets_whatsapp_template
           dataset_id: brutos_salesforce
           dump_mode: append
           infisical_secret_path: /salesforce_marketing_cloud
@@ -102,15 +178,18 @@ deployments:
       # -------------------------------------------------------------------
       # Adicione novas rotas aqui seguindo o mesmo padrão:
       #
-      # - cron: "0 9 * * *"
+      # - interval: 86400
+        anchor_date: "2021-01-01T13:00:00"
       #   timezone: America/Sao_Paulo
       #   active: false
-      #   slug: sfmc-<nome-da-rota>
-      #   flow_run_name: sfmc-<nome-da-rota>
+      #   slug: sfmc-<nome>
+      #   flow_run_name: sfmc-<nome>
       #   parameters:
       #     route: "/caminho/da/rota"
-      #     route_params: {}
-      #     query_params: {}
+      #     http_method: get   # ou post
+      #     query_params: {}   # apenas para GET
+      #     body_json: {}      # apenas para POST
+      #     page_size: 200
       #     table_id: <nome_da_tabela>
       #     dataset_id: brutos_salesforce
       #     dump_mode: append

--- a/pipelines/rj_crm__salesforce_api/prefect.yaml
+++ b/pipelines/rj_crm__salesforce_api/prefect.yaml
@@ -1,4 +1,4 @@
-name: rj_crm__disparo_template
+name: rj_crm__salesforce_api
 prefect-version: 3.4.3
 build:
   - prefect.deployments.steps.run_shell_script:
@@ -9,8 +9,8 @@ build:
       id: build-image
       requires: prefect-docker>=0.6.5
       image_name: ghcr.io/prefeitura-rio/prefect_rj_iplanrio/deployments
-      tag: rj_crm__disparo_template-{{ get-commit-hash.stdout }}
-      dockerfile: pipelines/rj_crm__disparo_template/Dockerfile
+      tag: rj_crm__salesforce_api-{{ get-commit-hash.stdout }}
+      dockerfile: pipelines/rj_crm__salesforce_api/Dockerfile
 push:
   - prefect_docker.deployments.steps.push_docker_image:
       requires: prefect-docker>=0.6.5
@@ -21,440 +21,98 @@ pull:
       directory: /opt/prefect/prefect_rj_iplanrio
 deployments:
 
-  - name: rj-crm--disparo-template-sf--staging
+  # -----------------------------------------------------------------------
+  # Deployment de staging
+  # -----------------------------------------------------------------------
+  - name: rj-crm--salesforce-api--staging
     version: '{{ build-image.tag }}'
-    entrypoint: pipelines/rj_crm__disparo_template/flow.py:rj_crm__disparo_template_sf
+    entrypoint: pipelines/rj_crm__salesforce_api/flow.py:rj_crm__salesforce_api
     work_pool:
       name: default-pool
       work_queue_name: default
       job_variables:
         image: '{{ build-image.image_name }}:{{ build-image.tag }}'
-        command: "uv run --package rj_crm__disparo_template -- prefect flow-run execute"
+        command: "uv run --package rj_crm__salesforce_api -- prefect flow-run execute"
         secretName: prefect-jobs-crm-registry-secrets-staging
         image_pull_policy: Always
     parameters:
-      campaign_name: disparo-template-sf
-      cost_center_id: 71
-      dataset_id: brutos_wetalkie
-      table_id: disparos_efetuados_sf
-      dump_mode: append
-      filter_dispatched_phones_or_cpfs: cpf
-      filter_duplicated_phones: false
-      filter_duplicated_cpfs: true
-      infisical_secret_path: /crm_disparo_template
+      infisical_secret_path: /salesforce_marketing_cloud
     schedules:
-# Schedule para testar flow na salesforce
-      - interval: 86400000
-        anchor_date: "2021-01-01T13:00:00"
-        timezone: America/Sao_Paulo
-        active: false
-        slug: sf-teste-confirma_agendamento_cadunico
-        flow_run_name: sf-teste-confirma_agendamento_cadunico
-        parameters:
-          flow_environment: staging
-          id_hsm: null
-          campaign_name: confirma_agendamento_cadunico_prod_v2
-          cost_center_id: 71
-          chunk_size: 1000
-          dataset_id: brutos_salesforce
-          table_id: disparos_efetuados_teste
-          dump_mode: append
-          test_mode: true
-          sleep_minutes: 1
-          filter_dispatched_phones_or_cpfs: null
-          filter_duplicated_phones: false
-          filter_duplicated_cpfs: false
-          whitelist_percentage: 0
-          infisical_secret_path: "/crm_disparo_template"
-          whitelist_environment: "production"
-          filter_failed_phones: false
-          force_add_on_whitelist_group: false
-          whitelist_replace_contacts: false
-          data_extension_filename: whatsapp_cadunico
-          query: |
-            SELECT * FROM rj-crm-registry-dev.teste.agendamento_cadunico_teste
-            WHERE nome_sobrenome LIKE "%patricia%"
 
-  # SF Teste - Dívida Ativa Cobrança
-      - interval: 86400000
-        anchor_date: "2021-01-01T13:00:00"
+      # -------------------------------------------------------------------
+      # Rota: GET /asset/v1/content/assets/{assetId}
+      # Tabela destino: content_assets
+      # Frequência: diária às 06:00 BRT (09:00 UTC)
+      # -------------------------------------------------------------------
+      - cron: "0 9 * * *"
         timezone: America/Sao_Paulo
         active: false
-        slug: sf-teste-pgm-divida-ativa-cobranca
-        flow_run_name: sf-teste-pgm-divida-ativa-cobranca
+        slug: sfmc-content-assets
+        flow_run_name: sfmc-content-assets
         parameters:
-          flow_environment: staging
-          campaign_name: pgm_divida_ativa_prod_v2
-          cost_center_id: 71
+          route: "/asset/v1/content/assets/{assetId}"
+          route_params:
+            # Substitua pelo assetId real que deseja ingerir.
+            # Para ingestão em lote, use a rota sem parâmetro de path:
+            # route: "/asset/v1/content/assets"
+            # query_params: {"$pageSize": 50, "scope": "Ours,Shared"}
+            assetId: "12345"
+          table_id: content_assets
           dataset_id: brutos_salesforce
-          table_id: disparos_efetuados_teste
           dump_mode: append
-          test_mode: true
-          sleep_minutes: 1
-          filter_dispatched_phones_or_cpfs: null
-          filter_duplicated_phones: false
-          filter_duplicated_cpfs: false
-          whitelist_percentage: 0
-          infisical_secret_path: "/crm_disparo_template"
-          whitelist_environment: "production"
-          filter_failed_phones: false
-          force_add_on_whitelist_group: false
-          whitelist_replace_contacts: false
-          data_extension_filename: whatsapp_pgm_divida_ativa_cobranca
-          query: |
-            SELECT * FROM `rj-crm-registry-dev`.teste.pgm_divida_ativa_cobranca
-            WHERE nome_sobrenome LIKE "%patricia%"
+          infisical_secret_path: /salesforce_marketing_cloud
 
-  # SF Teste - Dívida Ativa Lembrete
-      - interval: 864000000
-        anchor_date: "2021-01-01T13:00:00"
-        timezone: America/Sao_Paulo
-        active: false
-        slug: sf-teste-pgm-divida-ativa-lembrete
-        flow_run_name: sf-teste-pgm-divida-ativa-lembrete
-        parameters:
-          flow_environment: staging
-          campaign_name: pgmdividaativalembreteprodv1
-          cost_center_id: 71
-          dataset_id: brutos_salesforce
-          table_id: disparos_efetuados_teste
-          dump_mode: append
-          test_mode: true
-          sleep_minutes: 1
-          filter_dispatched_phones_or_cpfs: null
-          filter_duplicated_phones: false
-          filter_duplicated_cpfs: false
-          whitelist_percentage: 0
-          infisical_secret_path: "/crm_disparo_template"
-          whitelist_environment: "production"
-          filter_failed_phones: false
-          force_add_on_whitelist_group: false
-          whitelist_replace_contacts: false
-          data_extension_filename: whatsapp_pgm_divida_ativa_lembrete
-          query: |
-            SELECT * FROM `rj-crm-registry-dev`.teste.pgm_divida_ativa_lembrete
-            WHERE nome_sobrenome LIKE "%patricia%"
-
-  # SF Teste - Dívida Ativa Agradecimento
-      - interval: 864000000
-        anchor_date: "2021-01-01T13:00:00"
-        timezone: America/Sao_Paulo
-        active: false
-        slug: sf-teste-pgm-divida-ativa-agradecimento
-        flow_run_name: sf-teste-pgm-divida-ativa-agradecimento
-        parameters:
-          flow_environment: staging
-          campaign_name: pgmdividaativaconfirmapgtoprodv1
-          cost_center_id: 71
-          dataset_id: brutos_salesforce
-          table_id: disparos_efetuados_teste
-          dump_mode: append
-          test_mode: true
-          sleep_minutes: 1
-          filter_dispatched_phones_or_cpfs: null
-          filter_duplicated_phones: false
-          filter_duplicated_cpfs: false
-          whitelist_percentage: 0
-          infisical_secret_path: "/crm_disparo_template"
-          whitelist_environment: "production"
-          filter_failed_phones: false
-          force_add_on_whitelist_group: false
-          whitelist_replace_contacts: false
-          data_extension_filename: whatsapp_pgm_divida_ativa_agradecimento
-          query: |
-            SELECT * FROM `rj-crm-registry-dev`.teste.pgm_divida_ativa_agradecimento
-            WHERE nome_sobrenome LIKE "%patricia%"
-
-  # SF Teste - Puérperas Explica Pesquisa (D0)
-      - interval: 864000000
-        anchor_date: "2021-01-01T13:00:00"
-        timezone: America/Sao_Paulo
-        active: false
-        slug: sf-teste-sms-puerperas-explica-pesquisa
-        flow_run_name: sf-teste-sms-puerperas-explica-pesquisa
-        parameters:
-          flow_environment: staging
-          campaign_name: smspuerperasdisparo25
-          cost_center_id: 71
-          dataset_id: brutos_salesforce
-          table_id: disparos_efetuados_teste
-          dump_mode: append
-          test_mode: true
-          sleep_minutes: 1
-          filter_dispatched_phones_or_cpfs: null
-          filter_duplicated_phones: false
-          filter_duplicated_cpfs: false
-          whitelist_percentage: 0
-          infisical_secret_path: "/crm_disparo_template"
-          whitelist_environment: "production"
-          filter_failed_phones: false
-          force_add_on_whitelist_group: false
-          whitelist_replace_contacts: false
-          data_extension_filename: whatsapp_sms_puerperas_explica_pesquisa
-          query: |
-            SELECT * FROM `rj-crm-registry-dev`.teste.sms_puerperas_explica_pesquisa
-            WHERE nome LIKE "%patricia%"
-
-  # SF Teste - Puérperas Confirma Agendamento (D0)
-      - interval: 86400000
-        anchor_date: "2021-01-01T13:00:00"
-        timezone: America/Sao_Paulo
-        active: false
-        slug: sf-teste-sms-puerperas-confirma-agendamento
-        flow_run_name: sf-teste-sms-puerperas-confirma-agendamento
-        parameters:
-          flow_environment: staging
-          campaign_name: _sms_puerpera_disp1_gestantev2
-          cost_center_id: 71
-          dataset_id: brutos_salesforce
-          table_id: disparos_efetuados_teste
-          dump_mode: append
-          test_mode: true
-          sleep_minutes: 1
-          filter_dispatched_phones_or_cpfs: null
-          filter_duplicated_phones: false
-          filter_duplicated_cpfs: false
-          whitelist_percentage: 0
-          infisical_secret_path: "/crm_disparo_template"
-          whitelist_environment: "production"
-          filter_failed_phones: false
-          force_add_on_whitelist_group: false
-          whitelist_replace_contacts: false
-          data_extension_filename: whatsapp_sms_puerperas_confirma_agendamento
-          query: |
-            SELECT * FROM `rj-crm-registry-dev`.teste.sms_puerperas_confirma_agendamento
-            WHERE nome LIKE "%patricia%"
-
-  # SF Teste - Puérperas Pesquisa 1 (D1/D3/D5/D10)
-      - interval: 86400000
-        anchor_date: "2021-01-01T13:00:00"
-        timezone: America/Sao_Paulo
-        active: false
-        slug: sf-teste-sms-puerperas-pesquisa1
-        flow_run_name: sf-teste-sms-puerperas-pesquisa1
-        parameters:
-          flow_environment: staging
-          campaign_name: smspuerperasdisparo4v3
-          cost_center_id: 71
-          dataset_id: brutos_salesforce
-          table_id: disparos_efetuados_teste
-          dump_mode: append
-          test_mode: true
-          sleep_minutes: 1
-          filter_dispatched_phones_or_cpfs: null
-          filter_duplicated_phones: false
-          filter_duplicated_cpfs: false
-          whitelist_percentage: 0
-          infisical_secret_path: "/crm_disparo_template"
-          whitelist_environment: "production"
-          filter_failed_phones: false
-          force_add_on_whitelist_group: false
-          whitelist_replace_contacts: false
-          data_extension_filename: whatsapp_sms_puerperas_pesquisa1
-          query: |
-            SELECT * FROM `rj-crm-registry-dev`.teste.sms_puerperas_pesquisa1
-            WHERE nome LIKE "%patricia%"
-
-  # SF Teste - Puérperas Pesquisa 2 (D7)
-      - interval: 864000000
-        anchor_date: "2021-01-01T13:00:00"
-        timezone: America/Sao_Paulo
-        active: false
-        slug: sf-teste-sms-puerperas-pesquisa2
-        flow_run_name: sf-teste-sms-puerperas-pesquisa2
-        parameters:
-          flow_environment: staging
-          campaign_name: smspuerperadisparo6
-          cost_center_id: 71
-          dataset_id: brutos_salesforce
-          table_id: disparos_efetuados_teste
-          dump_mode: append
-          test_mode: true
-          sleep_minutes: 1
-          filter_dispatched_phones_or_cpfs: null
-          filter_duplicated_phones: false
-          filter_duplicated_cpfs: false
-          whitelist_percentage: 0
-          infisical_secret_path: "/crm_disparo_template"
-          whitelist_environment: "production"
-          filter_failed_phones: false
-          force_add_on_whitelist_group: false
-          whitelist_replace_contacts: false
-          data_extension_filename: whatsapp_sms_puerperas_pesquisa2
-          query: |
-            SELECT * FROM `rj-crm-registry-dev`.teste.sms_puerperas_pesquisa2
-            WHERE nome LIKE "%patricia%"
-
-  # SF Teste - Puérperas Pesquisa 3 (D13/D16/D19)
-      - interval: 86400000
-        anchor_date: "2021-01-01T13:00:00"
-        timezone: America/Sao_Paulo
-        active: false
-        slug: sf-teste-sms-puerperas-pesquisa3
-        flow_run_name: sf-teste-sms-puerperas-pesquisa3
-        parameters:
-          flow_environment: staging
-          campaign_name: smspuerperasdisparo9
-          cost_center_id: 71
-          dataset_id: brutos_salesforce
-          table_id: disparos_efetuados_teste
-          dump_mode: append
-          test_mode: true
-          sleep_minutes: 1
-          filter_dispatched_phones_or_cpfs: null
-          filter_duplicated_phones: false
-          filter_duplicated_cpfs: false
-          whitelist_percentage: 0
-          infisical_secret_path: "/crm_disparo_template"
-          whitelist_environment: "production"
-          filter_failed_phones: false
-          force_add_on_whitelist_group: false
-          whitelist_replace_contacts: false
-          data_extension_filename: whatsapp_sms_puerperas_pesquisa3
-          query: |
-            SELECT * FROM `rj-crm-registry-dev`.teste.sms_puerperas_pesquisa3
-            WHERE nome LIKE "%patricia%"
-
-  # SF Teste - Puérperas Pesquisa 4 (D22)
-      - interval: 86400000
-        anchor_date: "2021-01-01T13:00:00"
-        timezone: America/Sao_Paulo
-        active: false
-        slug: sf-teste-sms-puerperas-pesquisa4
-        flow_run_name: sf-teste-sms-puerperas-pesquisa4
-        parameters:
-          flow_environment: staging
-          campaign_name: smspuerperadisparo11
-          cost_center_id: 71
-          dataset_id: brutos_salesforce
-          table_id: disparos_efetuados_teste
-          dump_mode: append
-          test_mode: true
-          sleep_minutes: 1
-          filter_dispatched_phones_or_cpfs: null
-          filter_duplicated_phones: false
-          filter_duplicated_cpfs: false
-          whitelist_percentage: 0
-          infisical_secret_path: "/crm_disparo_template"
-          whitelist_environment: "production"
-          filter_failed_phones: false
-          force_add_on_whitelist_group: false
-          whitelist_replace_contacts: false
-          data_extension_filename: whatsapp_sms_puerperas_pesquisa4
-          query: |
-            SELECT * FROM `rj-crm-registry-dev`.teste.sms_puerperas_pesquisa4
-            WHERE SubscriberKey = "00000000001"
-
-  # SF Teste - Puérperas Pesquisa 5 (D25/D28)
-      - interval: 86400000
-        anchor_date: "2021-01-01T13:00:00"
-        timezone: America/Sao_Paulo
-        active: false
-        slug: sf-teste-sms-puerperas-pesquisa5
-        flow_run_name: sf-teste-sms-puerperas-pesquisa5
-        parameters:
-          flow_environment: staging
-          campaign_name: smspuerperasdisparo12
-          cost_center_id: 71
-          dataset_id: brutos_salesforce
-          table_id: disparos_efetuados_teste
-          dump_mode: append
-          test_mode: true
-          sleep_minutes: 1
-          filter_dispatched_phones_or_cpfs: null
-          filter_duplicated_phones: false
-          filter_duplicated_cpfs: false
-          whitelist_percentage: 0
-          infisical_secret_path: "/crm_disparo_template"
-          whitelist_environment: "production"
-          filter_failed_phones: false
-          force_add_on_whitelist_group: false
-          whitelist_replace_contacts: false
-          data_extension_filename: whatsapp_sms_puerperas_pesquisa5
-          query: |
-            SELECT * FROM `rj-crm-registry-dev`.teste.sms_puerperas_pesquisa5
-            WHERE nome LIKE "%patricia%"
-
-  # SF Teste - Puérperas Pesquisa 6 (D34)
-      - interval: 864000000
-        anchor_date: "2021-01-01T13:00:00"
-        timezone: America/Sao_Paulo
-        active: false
-        slug: sf-teste-sms-puerperas-pesquisa6
-        flow_run_name: sf-teste-sms-puerperas-pesquisa6
-        parameters:
-          flow_environment: staging
-          campaign_name: smspuerperasdisparo14
-          cost_center_id: 71
-          dataset_id: brutos_salesforce
-          table_id: disparos_efetuados_teste
-          dump_mode: append
-          test_mode: true
-          sleep_minutes: 1
-          filter_dispatched_phones_or_cpfs: null
-          filter_duplicated_phones: false
-          filter_duplicated_cpfs: false
-          whitelist_percentage: 0
-          infisical_secret_path: "/crm_disparo_template"
-          whitelist_environment: "production"
-          filter_failed_phones: false
-          force_add_on_whitelist_group: false
-          whitelist_replace_contacts: false
-          data_extension_filename: whatsapp_sms_puerperas_pesquisa6
-          query: |
-            SELECT * FROM `rj-crm-registry-dev`.teste.sms_puerperas_pesquisa6
-            WHERE nome LIKE "%patricia%"
-
-  # SF Teste - Puérperas Pesquisa 7 (D40)
-      - interval: 864000000
-        anchor_date: "2021-01-01T13:00:00"
-        timezone: America/Sao_Paulo
-        active: false
-        slug: sf-teste-sms-puerperas-pesquisa7
-        flow_run_name: sf-teste-sms-puerperas-pesquisa7
-        parameters:
-          flow_environment: staging
-          campaign_name: smspuerperasdisparo152
-          cost_center_id: 71
-          dataset_id: brutos_salesforce
-          table_id: disparos_efetuados_teste
-          dump_mode: append
-          test_mode: true
-          sleep_minutes: 1
-          filter_dispatched_phones_or_cpfs: null
-          filter_duplicated_phones: false
-          filter_duplicated_cpfs: false
-          whitelist_percentage: 0
-          infisical_secret_path: "/crm_disparo_template"
-          whitelist_environment: "production"
-          filter_failed_phones: false
-          force_add_on_whitelist_group: false
-          whitelist_replace_contacts: false
-          data_extension_filename: whatsapp_sms_puerperas_pesquisa7
-          query: |-
-            SELECT * FROM `rj-crm-registry-dev`.teste.sms_puerperas_pesquisa7
-            WHERE nome LIKE "%patricia%"
-  - name: rj-crm--disparo-template-sf--prod
+  # -----------------------------------------------------------------------
+  # Deployment de produção
+  # -----------------------------------------------------------------------
+  - name: rj-crm--salesforce-api--prod
     version: '{{ get-commit-hash.stdout }}'
-    entrypoint: pipelines/rj_crm__disparo_template/flow.py:rj_crm__disparo_template_sf
+    entrypoint: pipelines/rj_crm__salesforce_api/flow.py:rj_crm__salesforce_api
     work_pool:
       name: default-pool
       work_queue_name: default
       job_variables:
         image: '{{ build-image.image_name }}:{{ build-image.tag }}'
-        command: "uv run --package rj_crm__disparo_template -- prefect flow-run execute"
+        command: "uv run --package rj_crm__salesforce_api -- prefect flow-run execute"
         secretName: prefect-jobs-crm-registry-secrets
         image_pull_policy: Always
     parameters:
-      campaign_name: disparo-template-sf
-      cost_center_id: 71
-      dataset_id: brutos_wetalkie
-      table_id: disparos_efetuados_sf
-      dump_mode: append
-      filter_dispatched_phones_or_cpfs: cpf
-      filter_duplicated_phones: false
-      filter_duplicated_cpfs: true
-      infisical_secret_path: /crm_disparo_template
+      infisical_secret_path: /salesforce_marketing_cloud
     schedules:
 
-  
+      # -------------------------------------------------------------------
+      # Rota: GET /asset/v1/content/assets/{assetId}
+      # Tabela destino: content_assets
+      # Frequência: diária às 06:00 BRT (09:00 UTC)
+      # -------------------------------------------------------------------
+      - cron: "0 9 * * *"
+        timezone: America/Sao_Paulo
+        active: false
+        slug: sfmc-content-assets
+        flow_run_name: sfmc-content-assets
+        parameters:
+          route: "/asset/v1/content/assets/{assetId}"
+          route_params:
+            assetId: "12345"
+          table_id: content_assets
+          dataset_id: brutos_salesforce
+          dump_mode: append
+          infisical_secret_path: /salesforce_marketing_cloud
+
+      # -------------------------------------------------------------------
+      # Adicione novas rotas aqui seguindo o mesmo padrão:
+      #
+      # - cron: "0 9 * * *"
+      #   timezone: America/Sao_Paulo
+      #   active: false
+      #   slug: sfmc-<nome-da-rota>
+      #   flow_run_name: sfmc-<nome-da-rota>
+      #   parameters:
+      #     route: "/caminho/da/rota"
+      #     route_params: {}
+      #     query_params: {}
+      #     table_id: <nome_da_tabela>
+      #     dataset_id: brutos_salesforce
+      #     dump_mode: append
+      #     infisical_secret_path: /salesforce_marketing_cloud
+      # -------------------------------------------------------------------

--- a/pipelines/rj_crm__salesforce_api/pyproject.toml
+++ b/pipelines/rj_crm__salesforce_api/pyproject.toml
@@ -1,0 +1,31 @@
+[project]
+name = "rj_crm__disparo_template"
+version = "0.1.0"
+description = "Pipeline de disparo de template"
+dependencies = [
+    "prefect_rj_iplanrio",
+    "dbt-bigquery>=1.6.1",
+    "google-cloud-storage==2.10.0",
+    "prefect==3.4.9",
+    "prefect-docker>=0.6.5",
+    "prefeitura-rio[actions] @ git+https://github.com/prefeitura-rio/prefeitura-rio@54593ddff444158b0ecbab5514c5cde4d44012c0",
+    "geopy==2.4.1",
+    "opencage==3.0.4",
+    "python-dotenv==1.0.1",
+    "unidecode==1.3.8",
+    "pendulum==3.0.0",
+    "simplejson==3.20.1",
+    "openlocationcode==1.0.1",
+    "dbt-core>=1.8.0",
+    "mutagen==1.47.0",
+    "google-cloud-speech==2.32.0",
+    "marshmallow==3.26.1",
+    "gitpython==3.1.44",
+    "discord-py==2.5.2",
+    "pydantic>=2.0.0",
+    "ruamel.yaml==0.18.6",
+    "paramiko>=3.0.0",
+]
+
+[tool.uv.sources]
+prefect_rj_iplanrio = { workspace = true }

--- a/pipelines/rj_crm__salesforce_api/pyproject.toml
+++ b/pipelines/rj_crm__salesforce_api/pyproject.toml
@@ -1,30 +1,17 @@
 [project]
-name = "rj_crm__disparo_template"
+name = "rj_crm__salesforce_api"
 version = "0.1.0"
-description = "Pipeline de disparo de template"
+description = "Pipeline genérica de ingestão de rotas GET da Salesforce Marketing Cloud REST API"
 dependencies = [
     "prefect_rj_iplanrio",
-    "dbt-bigquery>=1.6.1",
     "google-cloud-storage==2.10.0",
     "prefect==3.4.9",
     "prefect-docker>=0.6.5",
-    "prefeitura-rio[actions] @ git+https://github.com/prefeitura-rio/prefeitura-rio@54593ddff444158b0ecbab5514c5cde4d44012c0",
-    "geopy==2.4.1",
-    "opencage==3.0.4",
     "python-dotenv==1.0.1",
-    "unidecode==1.3.8",
     "pendulum==3.0.0",
-    "simplejson==3.20.1",
-    "openlocationcode==1.0.1",
-    "dbt-core>=1.8.0",
-    "mutagen==1.47.0",
-    "google-cloud-speech==2.32.0",
-    "marshmallow==3.26.1",
-    "gitpython==3.1.44",
-    "discord-py==2.5.2",
+    "requests>=2.31.0",
+    "pandas>=2.0.0",
     "pydantic>=2.0.0",
-    "ruamel.yaml==0.18.6",
-    "paramiko>=3.0.0",
 ]
 
 [tool.uv.sources]

--- a/pipelines/rj_crm__salesforce_api/tasks.py
+++ b/pipelines/rj_crm__salesforce_api/tasks.py
@@ -40,10 +40,10 @@ def _get_sfmc_credentials() -> dict[str, str]:
         dict com as chaves: client_id, client_secret, auth_url, rest_base_url
     """
     return {
-        "client_id": getenv_or_action("sfmc_client_id"),
-        "client_secret": getenv_or_action("sfmc_client_secret"),
-        "auth_url": getenv_or_action("sfmc_auth_url").rstrip("/"),
-        "rest_base_url": getenv_or_action("sfmc_rest_base_url").rstrip("/"),
+        "client_id": getenv_or_action("API_SFMC_CLIENT_ID"),
+        "client_secret": getenv_or_action("API_SFMC_CLIENT_SECRET"),
+        "auth_url": getenv_or_action("API_SFMC_AUTH_URL").rstrip("/"),
+        "rest_base_url": getenv_or_action("API_SFMC_REST_BASE_URL").rstrip("/"),
     }
 
 

--- a/pipelines/rj_crm__salesforce_api/tasks.py
+++ b/pipelines/rj_crm__salesforce_api/tasks.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+"""
+Tasks para ingestão de dados via Salesforce Marketing Cloud REST API.
+
+Autenticação via OAuth2 Client Credentials (grant_type=client_credentials).
+Credenciais necessárias no Infisical:
+  - sfmc_client_id      : Client ID da Connected App no SFMC
+  - sfmc_client_secret  : Client Secret da Connected App no SFMC
+  - sfmc_auth_url       : URL de autenticação (ex: https://<tenant>.auth.marketingcloudapis.com)
+  - sfmc_rest_base_url  : URL base da REST API  (ex: https://<tenant>.rest.marketingcloudapis.com)
+"""
+
+import json
+import os
+from datetime import date
+from typing import Any
+
+import pandas as pd
+import requests
+from prefect import task
+
+
+def _get_sfmc_credentials() -> dict[str, str]:
+    """
+    Lê as credenciais da SFMC a partir das variáveis de ambiente
+    (injetadas pelo Infisical via inject_bd_credentials_task ou secretName).
+
+    Returns:
+        dict com as chaves: client_id, client_secret, auth_url, rest_base_url
+    """
+    client_id = os.environ["sfmc_client_id"]
+    client_secret = os.environ["sfmc_client_secret"]
+    auth_url = os.environ["sfmc_auth_url"].rstrip("/")
+    rest_base_url = os.environ["sfmc_rest_base_url"].rstrip("/")
+    return {
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "auth_url": auth_url,
+        "rest_base_url": rest_base_url,
+    }
+
+
+def _get_access_token(client_id: str, client_secret: str, auth_url: str) -> str:
+    """
+    Obtém um access token OAuth2 da Salesforce Marketing Cloud.
+
+    Args:
+        client_id: Client ID da Connected App.
+        client_secret: Client Secret da Connected App.
+        auth_url: URL base de autenticação do tenant SFMC.
+
+    Returns:
+        Access token como string.
+    """
+    token_url = f"{auth_url}/v2/token"
+    payload = {
+        "grant_type": "client_credentials",
+        "client_id": client_id,
+        "client_secret": client_secret,
+    }
+    response = requests.post(token_url, json=payload, timeout=30)
+    response.raise_for_status()
+    token_data = response.json()
+    access_token = token_data["access_token"]
+    print(f"[SFMC] Token obtido com sucesso. Expira em {token_data.get('expires_in', 'N/A')}s.")
+    return access_token
+
+
+@task(log_prints=True)
+def fetch_sfmc_route(
+    route: str,
+    route_params: dict[str, Any] | None = None,
+    query_params: dict[str, Any] | None = None,
+) -> list[dict]:
+    """
+    Chama uma rota GET da Salesforce Marketing Cloud REST API e retorna os dados.
+
+    A rota pode conter placeholders no estilo {chave} que serão substituídos
+    pelos valores de `route_params`. Ex: "/asset/v1/content/assets/{assetId}"
+    com route_params={"assetId": "12345"} resulta em "/asset/v1/content/assets/12345".
+
+    Se a resposta for uma lista (campo "items"), retorna todos os itens.
+    Se for um objeto único, retorna-o encapsulado em lista.
+
+    Args:
+        route: Rota relativa da API. Ex: "/asset/v1/content/assets/{assetId}".
+        route_params: Dicionário de parâmetros para substituição na rota.
+        query_params: Query string parameters adicionais (ex: {"$page": 1, "$pageSize": 50}).
+
+    Returns:
+        Lista de dicionários com os dados retornados pela API.
+    """
+    creds = _get_sfmc_credentials()
+    access_token = _get_access_token(
+        client_id=creds["client_id"],
+        client_secret=creds["client_secret"],
+        auth_url=creds["auth_url"],
+    )
+
+    # Substituir placeholders na rota
+    resolved_route = route
+    if route_params:
+        resolved_route = route.format(**route_params)
+
+    url = f"{creds['rest_base_url']}{resolved_route}"
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+    }
+
+    print(f"[SFMC] Chamando GET {url}")
+    if query_params:
+        print(f"[SFMC] Query params: {query_params}")
+
+    response = requests.get(url, headers=headers, params=query_params, timeout=60)
+    response.raise_for_status()
+
+    data = response.json()
+
+    # Print dos dados recebidos para inspeção
+    print(f"[SFMC] Resposta recebida (primeiros 2000 chars):")
+    print(json.dumps(data, indent=2, ensure_ascii=False)[:2000])
+
+    # Normaliza para lista
+    if isinstance(data, list):
+        records = data
+    elif "items" in data:
+        records = data["items"]
+        print(f"[SFMC] Total de itens retornados (campo 'items'): {len(records)}")
+    else:
+        # Objeto único — encapsula em lista
+        records = [data]
+        print(f"[SFMC] Objeto único retornado, encapsulado em lista.")
+
+    print(f"[SFMC] Total de registros: {len(records)}")
+    return records
+
+
+@task(log_prints=True)
+def build_dataframe(
+    records: list[dict],
+    partition_date: date | None = None,
+) -> pd.DataFrame:
+    """
+    Constrói um DataFrame a partir dos registros retornados pela API.
+
+    Cada linha do DataFrame contém:
+      - data: JSON string com o conteúdo do registro (todos os campos originais)
+      - data_particao: data de particionamento (hoje se não informada)
+
+    Args:
+        records: Lista de dicionários retornados por fetch_sfmc_route.
+        partition_date: Data de particionamento. Padrão: data de hoje.
+
+    Returns:
+        DataFrame com colunas 'data' e 'data_particao'.
+    """
+    if partition_date is None:
+        partition_date = date.today()
+
+    rows = []
+    for record in records:
+        rows.append(
+            {
+                "data": json.dumps(record, ensure_ascii=False),
+                "data_particao": str(partition_date),
+            }
+        )
+
+    df = pd.DataFrame(rows, columns=["data", "data_particao"])
+    print(f"[SFMC] DataFrame criado com {len(df)} linhas e colunas: {list(df.columns)}")
+    return df

--- a/pipelines/rj_crm__salesforce_api/tasks.py
+++ b/pipelines/rj_crm__salesforce_api/tasks.py
@@ -8,17 +8,25 @@ Credenciais necessárias no Infisical:
   - sfmc_client_secret  : Client Secret da Connected App no SFMC
   - sfmc_auth_url       : URL de autenticação (ex: https://<tenant>.auth.marketingcloudapis.com)
   - sfmc_rest_base_url  : URL base da REST API  (ex: https://<tenant>.rest.marketingcloudapis.com)
+
+Métodos suportados (parâmetro http_method no flow):
+  - "get"  : GET com paginação automática via $page / $pageSize
+  - "post" : POST com body JSON e paginação automática via page.page / page.pageSize
 """
 
 import json
 import os
 from datetime import date
-from typing import Any
+from typing import Any, Literal
 
 import pandas as pd
 import requests
 from prefect import task
 
+
+# ---------------------------------------------------------------------------
+# Credenciais e autenticação
+# ---------------------------------------------------------------------------
 
 def _get_sfmc_credentials() -> dict[str, str]:
     """
@@ -28,15 +36,11 @@ def _get_sfmc_credentials() -> dict[str, str]:
     Returns:
         dict com as chaves: client_id, client_secret, auth_url, rest_base_url
     """
-    client_id = os.environ["sfmc_client_id"]
-    client_secret = os.environ["sfmc_client_secret"]
-    auth_url = os.environ["sfmc_auth_url"].rstrip("/")
-    rest_base_url = os.environ["sfmc_rest_base_url"].rstrip("/")
     return {
-        "client_id": client_id,
-        "client_secret": client_secret,
-        "auth_url": auth_url,
-        "rest_base_url": rest_base_url,
+        "client_id": os.environ["sfmc_client_id"],
+        "client_secret": os.environ["sfmc_client_secret"],
+        "auth_url": os.environ["sfmc_auth_url"].rstrip("/"),
+        "rest_base_url": os.environ["sfmc_rest_base_url"].rstrip("/"),
     }
 
 
@@ -61,34 +65,151 @@ def _get_access_token(client_id: str, client_secret: str, auth_url: str) -> str:
     response = requests.post(token_url, json=payload, timeout=30)
     response.raise_for_status()
     token_data = response.json()
-    access_token = token_data["access_token"]
     print(f"[SFMC] Token obtido com sucesso. Expira em {token_data.get('expires_in', 'N/A')}s.")
-    return access_token
+    return token_data["access_token"]
 
+
+# ---------------------------------------------------------------------------
+# GET com paginação automática
+# ---------------------------------------------------------------------------
+
+def _fetch_all_pages_get(
+    url: str,
+    headers: dict,
+    query_params: dict[str, Any],
+    page_size: int,
+) -> list[dict]:
+    """
+    Itera todas as páginas de uma rota GET do SFMC usando $page e $pageSize.
+
+    A resposta deve conter os campos `count` (total de registros) e `items`
+    (lista de registros da página atual).
+
+    Args:
+        url: URL completa da rota.
+        headers: Headers HTTP (Authorization, Content-Type).
+        query_params: Query params base (sem $page/$pageSize — adicionados aqui).
+        page_size: Quantidade de registros por página.
+
+    Returns:
+        Lista com todos os registros de todas as páginas.
+    """
+    all_records = []
+    page = 1
+
+    while True:
+        params = {**query_params, "$page": page, "$pageSize": page_size}
+        print(f"[SFMC][GET] Buscando página {page} (pageSize={page_size})...")
+
+        response = requests.get(url, headers=headers, params=params, timeout=60)
+        response.raise_for_status()
+        data = response.json()
+
+        print(f"[SFMC][GET] Resposta da página {page} (primeiros 2000 chars):")
+        print(json.dumps(data, indent=2, ensure_ascii=False)[:2000])
+
+        items = data.get("items", [])
+        all_records.extend(items)
+
+        total = data.get("count", len(items))
+        print(f"[SFMC][GET] Página {page}: {len(items)} registros. Total acumulado: {len(all_records)} / {total}.")
+
+        if len(all_records) >= total or not items:
+            break
+
+        page += 1
+
+    return all_records
+
+
+# ---------------------------------------------------------------------------
+# POST /query com paginação automática
+# ---------------------------------------------------------------------------
+
+def _fetch_all_pages_post(
+    url: str,
+    headers: dict,
+    body: dict[str, Any],
+    page_size: int,
+) -> list[dict]:
+    """
+    Itera todas as páginas de uma rota POST /query do SFMC.
+
+    O body deve conter uma chave `page` com `page` e `pageSize`.
+    A resposta deve conter `count` (total) e `items` (página atual).
+
+    Args:
+        url: URL completa da rota (ex: .../asset/v1/content/assets/query).
+        headers: Headers HTTP (Authorization, Content-Type).
+        body: Body JSON base. A chave `page` é sobrescrita a cada iteração.
+        page_size: Quantidade de registros por página.
+
+    Returns:
+        Lista com todos os registros de todas as páginas.
+    """
+    all_records = []
+    page = 1
+
+    while True:
+        page_body = {
+            **body,
+            "page": {"page": page, "pageSize": page_size},
+        }
+        print(f"[SFMC][POST] Buscando página {page} (pageSize={page_size})...")
+
+        response = requests.post(url, headers=headers, json=page_body, timeout=60)
+        response.raise_for_status()
+        data = response.json()
+
+        print(f"[SFMC][POST] Resposta da página {page} (primeiros 2000 chars):")
+        print(json.dumps(data, indent=2, ensure_ascii=False)[:2000])
+
+        items = data.get("items", [])
+        all_records.extend(items)
+
+        total = data.get("count", len(items))
+        print(f"[SFMC][POST] Página {page}: {len(items)} registros. Total acumulado: {len(all_records)} / {total}.")
+
+        if len(all_records) >= total or not items:
+            break
+
+        page += 1
+
+    return all_records
+
+
+# ---------------------------------------------------------------------------
+# Task principal
+# ---------------------------------------------------------------------------
 
 @task(log_prints=True)
 def fetch_sfmc_route(
     route: str,
+    http_method: Literal["get", "post"] = "get",
     route_params: dict[str, Any] | None = None,
     query_params: dict[str, Any] | None = None,
+    body_json: dict[str, Any] | None = None,
+    page_size: int = 200,
 ) -> list[dict]:
     """
-    Chama uma rota GET da Salesforce Marketing Cloud REST API e retorna os dados.
-
-    A rota pode conter placeholders no estilo {chave} que serão substituídos
-    pelos valores de `route_params`. Ex: "/asset/v1/content/assets/{assetId}"
-    com route_params={"assetId": "12345"} resulta em "/asset/v1/content/assets/12345".
-
-    Se a resposta for uma lista (campo "items"), retorna todos os itens.
-    Se for um objeto único, retorna-o encapsulado em lista.
+    Chama uma rota da Salesforce Marketing Cloud REST API e retorna todos os registros,
+    iterando automaticamente todas as páginas.
 
     Args:
-        route: Rota relativa da API. Ex: "/asset/v1/content/assets/{assetId}".
-        route_params: Dicionário de parâmetros para substituição na rota.
-        query_params: Query string parameters adicionais (ex: {"$page": 1, "$pageSize": 50}).
+        route: Rota relativa da API. Pode conter placeholders {chave}.
+               Ex: "/asset/v1/content/assets" ou "/asset/v1/content/assets/query"
+        http_method: Método HTTP a usar. "get" ou "post". Padrão: "get".
+        route_params: Substituição de placeholders na rota.
+                      Ex: {"assetId": "12345"} para "/asset/v1/content/assets/{assetId}".
+        query_params: Query string parameters adicionais para GET.
+                      Ex: {"scope": "Ours,Shared"}. $page e $pageSize são gerenciados
+                      automaticamente — não é necessário informar.
+        body_json: Body JSON para POST. A chave "page" é gerenciada automaticamente
+                   pela paginação — não é necessário informar page/pageSize aqui.
+        page_size: Quantidade de registros por página. Padrão: 200.
 
     Returns:
-        Lista de dicionários com os dados retornados pela API.
+        Lista com todos os registros retornados pela API (todas as páginas).
     """
     creds = _get_sfmc_credentials()
     access_token = _get_access_token(
@@ -98,43 +219,40 @@ def fetch_sfmc_route(
     )
 
     # Substituir placeholders na rota
-    resolved_route = route
-    if route_params:
-        resolved_route = route.format(**route_params)
-
+    resolved_route = route.format(**(route_params or {}))
     url = f"{creds['rest_base_url']}{resolved_route}"
+
     headers = {
         "Authorization": f"Bearer {access_token}",
         "Content-Type": "application/json",
     }
 
-    print(f"[SFMC] Chamando GET {url}")
-    if query_params:
-        print(f"[SFMC] Query params: {query_params}")
+    print(f"[SFMC] Método: {http_method.upper()} | URL: {url}")
 
-    response = requests.get(url, headers=headers, params=query_params, timeout=60)
-    response.raise_for_status()
-
-    data = response.json()
-
-    # Print dos dados recebidos para inspeção
-    print(f"[SFMC] Resposta recebida (primeiros 2000 chars):")
-    print(json.dumps(data, indent=2, ensure_ascii=False)[:2000])
-
-    # Normaliza para lista
-    if isinstance(data, list):
-        records = data
-    elif "items" in data:
-        records = data["items"]
-        print(f"[SFMC] Total de itens retornados (campo 'items'): {len(records)}")
+    if http_method == "get":
+        records = _fetch_all_pages_get(
+            url=url,
+            headers=headers,
+            query_params=query_params or {},
+            page_size=page_size,
+        )
+    elif http_method == "post":
+        records = _fetch_all_pages_post(
+            url=url,
+            headers=headers,
+            body=body_json or {},
+            page_size=page_size,
+        )
     else:
-        # Objeto único — encapsula em lista
-        records = [data]
-        print(f"[SFMC] Objeto único retornado, encapsulado em lista.")
+        raise ValueError(f"http_method inválido: '{http_method}'. Use 'get' ou 'post'.")
 
-    print(f"[SFMC] Total de registros: {len(records)}")
+    print(f"[SFMC] Total de registros coletados (todas as páginas): {len(records)}")
     return records
 
+
+# ---------------------------------------------------------------------------
+# Task de construção do DataFrame
+# ---------------------------------------------------------------------------
 
 @task(log_prints=True)
 def build_dataframe(
@@ -144,8 +262,8 @@ def build_dataframe(
     """
     Constrói um DataFrame a partir dos registros retornados pela API.
 
-    Cada linha do DataFrame contém:
-      - data: JSON string com o conteúdo do registro (todos os campos originais)
+    Cada linha contém:
+      - data: JSON string com o conteúdo completo do registro
       - data_particao: data de particionamento (hoje se não informada)
 
     Args:
@@ -158,14 +276,13 @@ def build_dataframe(
     if partition_date is None:
         partition_date = date.today()
 
-    rows = []
-    for record in records:
-        rows.append(
-            {
-                "data": json.dumps(record, ensure_ascii=False),
-                "data_particao": str(partition_date),
-            }
-        )
+    rows = [
+        {
+            "data": json.dumps(record, ensure_ascii=False),
+            "data_particao": str(partition_date),
+        }
+        for record in records
+    ]
 
     df = pd.DataFrame(rows, columns=["data", "data_particao"])
     print(f"[SFMC] DataFrame criado com {len(df)} linhas e colunas: {list(df.columns)}")

--- a/pipelines/rj_crm__salesforce_api/tasks.py
+++ b/pipelines/rj_crm__salesforce_api/tasks.py
@@ -15,12 +15,12 @@ Métodos suportados (parâmetro http_method no flow):
 """
 
 import json
-import os
 from datetime import date
 from typing import Any, Literal
 
 import pandas as pd
 import requests
+from iplanrio.pipelines_utils.env import getenv_or_action
 from prefect import task
 
 
@@ -31,16 +31,19 @@ from prefect import task
 def _get_sfmc_credentials() -> dict[str, str]:
     """
     Lê as credenciais da SFMC a partir das variáveis de ambiente
-    (injetadas pelo Infisical via inject_bd_credentials_task ou secretName).
+    injetadas pelo Infisical (via secretName no job do Kubernetes).
+
+    As variáveis são lidas com getenv_or_action, que lança erro claro
+    caso a variável não esteja definida no ambiente.
 
     Returns:
         dict com as chaves: client_id, client_secret, auth_url, rest_base_url
     """
     return {
-        "client_id": os.environ["sfmc_client_id"],
-        "client_secret": os.environ["sfmc_client_secret"],
-        "auth_url": os.environ["sfmc_auth_url"].rstrip("/"),
-        "rest_base_url": os.environ["sfmc_rest_base_url"].rstrip("/"),
+        "client_id": getenv_or_action("sfmc_client_id"),
+        "client_secret": getenv_or_action("sfmc_client_secret"),
+        "auth_url": getenv_or_action("sfmc_auth_url").rstrip("/"),
+        "rest_base_url": getenv_or_action("sfmc_rest_base_url").rstrip("/"),
     }
 
 


### PR DESCRIPTION
Mudei o nome das variáveis de ambiente desse fluxo para usar o mesmo nome do fluxo salesforce api. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novas Funcionalidades**
  * Adicionada a pipeline **Get History Data** para extrair automaticamente Data Extensions do SFMC com sufixo de histórico, consolidando linhas e tipos e registrando sucesso/erro por conjunto.
  * Adicionada uma pipeline genérica de ingestão da **Salesforce Marketing Cloud REST API**, com paginação para rotas **GET** e **POST** e geração de dados particionados.
  * Incluídas configurações de **build/execução Docker** e **deployments** com schedules em **staging** e **produção** (incluindo execução diária).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->