### PR TITLE
fix(ci): require open PR to master before staging Prefect deploy

### DIFF
--- a/.github/workflows/deploy-prefect-flows-staging.yaml
+++ b/.github/workflows/deploy-prefect-flows-staging.yaml
@@ -38,13 +38,39 @@ jobs:
   deploy-prefect-staging-flows:
     name: Deploy Prefect staging flows
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
+      - name: Check for open PR targeting master
+        id: check_pr
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pr_count=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --head "${{ github.ref_name }}" \
+            --base master \
+            --state open \
+            --json number \
+            --jq 'length')
+
+          if [ "$pr_count" -gt 0 ]; then
+            echo "has_open_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_open_pr=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No open PR from '${{ github.ref_name }}' targeting 'master' was found. Skipping staging deploy."
+          fi
+
       - name: Checkout repository
+        if: github.event_name != 'push' || steps.check_pr.outputs.has_open_pr == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Deploy Prefect flows
+        if: github.event_name != 'push' || steps.check_pr.outputs.has_open_pr == 'true'
         uses: ./.github/actions/deploy-prefect-flows
         with:
           environment: staging


### PR DESCRIPTION
## Bug

Pushes to `staging/*` branches were unconditionally deploying to the staging Prefect environment, regardless of whether an open PR to `master` existed.

Intended policy:
- Commits on `master` → deploy to production, schedules enabled.
- Commits on `staging/*` → deploy to staging, schedules disabled, **only if** there's an open PR from that branch into `master`.

The PR-gate half of this policy was never implemented in code. `.github/workflows/deploy-prefect-flows-staging.yaml` triggers on any `push` to `staging/*` (paths: `pipelines/**`) with no check for PR existence — confirmed by reading the workflow YAML, the composite action `.github/actions/deploy-prefect-flows/action.yaml`, and `.github/scripts/deploy_prefect_flows.py` in full (no GitHub API / pull_request references anywhere).

Empirical confirmation: `staging/disparos-sf-tabela-simples` has zero PRs ever opened (checked open/closed/all), yet has 20+ consecutive successful staging deploy runs since 2026-07-07. This affects every `staging/*` branch, not just this one — it was just the most visible because it's actively being pushed to right now.

## Fix

Add a pre-check step to `deploy-prefect-flows-staging.yaml` using the GitHub CLI (`gh pr list --head <branch> --base master --state open`) with the built-in `GITHUB_TOKEN`. If no open PR exists, checkout and deploy steps are skipped (job succeeds with a `::notice::`, does not fail CI). `workflow_dispatch` manual runs are unaffected and always proceed regardless of PR status.

## Testing

- Validated workflow YAML syntax with `python3 -c "import yaml; yaml.safe_load(...)"`.
- Verified via `gh pr list` that none of the 100 `staging/*` branches currently ahead of master touch this workflow file, so no conflicts expected when merging master back into them post-merge.
- Not able to trigger a live CI run pre-merge since `push` triggers require the branch to exist with this file — will verify behavior on the next staging push after merge (e.g. via a branch with an open PR vs. one without).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correções**
  * Ajustado o fluxo de implantação em staging para executar apenas quando houver uma solicitação de mudança aberta para a branch de destino.
  * Adicionadas permissões explícitas para leitura do conteúdo do repositório e das solicitações de mudança.
  * Evitadas execuções desnecessárias de checkout e implantação em atualizações diretas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->