### PR TITLE
turn off cadunico dispatch from api datametrica agendamento flow

### DIFF
--- a/pipelines/rj_smas__api_datametrica_agendamentos/flow.py
+++ b/pipelines/rj_smas__api_datametrica_agendamentos/flow.py
@@ -111,27 +111,28 @@ def rj_smas__api_datametrica_agendamentos(
     print("\n\n******* Triggering cadunico dispatch flow... *******")
 
     cadunico_params = {
-        "query": None,
-        "id_hsm": 101,
+        "campaign_name": "confirma_agendamento_cadunico_prod_v2",
+        "data_extension_filename": "whatsapp_cadunico",
+        "de_columns": ["nome_sobrenome", "unidade_cras", "data", "hora", "endereco"],
+        "dataset_id": "brutos_salesforce",
         "table_id": "disparos_efetuados",
         "dump_mode": "append",
-        "test_mode": None,
+        "test_mode": False,
         "chunk_size": 1000,
-        "dataset_id": "brutos_wetalkie",
-        "days_ahead": "2",
-        "campaign_name": "smas-cadunico-prod",
-        "sleep_minutes": 2,
-        "cost_center_id": 71,
+        "sleep_minutes": 1,
         "flow_environment": "production",
-        "query_processor_name": "skip_weekends",
+        # "query_processor_name": "skip_weekends",
+        # "days_ahead": "2",
+        "filter_dispatched_phones_or_cpfs": None,
+        "filter_duplicated_phones": False,
+        "filter_duplicated_cpfs": True,
         "whitelist_percentage": 0,
-        "infisical_secret_path": "/wetalkie",
+        "infisical_secret_path": "/crm_disparo_template",
         "whitelist_environment": "production",
+        "query_file": "queries/confirma_agendamento_cadunico.sql",
     }
-    run_deployment(
-        name="rj-smas--disparo-cadunico/rj-smas--disparo-cadunico--prod",
-        parameters=cadunico_params,
-        timeout=0,
-    )
-    # rj_smas__disparo_cadunico(**cadunico_params)
-    # run_deployment(name="rj-smas--disparo-cadunico--prod", timeout=0)
+    # run_deployment(
+    #     name="rj-crm--disparo-template-sf/rj-crm--disparo-template-sf--prod",
+    #     parameters=cadunico_params,
+    #     timeout=0,
+    # )

--- a/pipelines/rj_smas__api_datametrica_agendamentos/prefect.yaml
+++ b/pipelines/rj_smas__api_datametrica_agendamentos/prefect.yaml
@@ -60,6 +60,10 @@ deployments:
       materialize_after_dump: true
       date: null  # null usa o próximo dia automaticamente
       infisical_secret_path: /api-datametrica
-    #schedules:
-    #  - cron: "0 10 * * *"  # Diariamente às 10:00
+    schedules:
+    #  - cron: "0 8 * * *"  # Diariamente às 10:00
     #    timezone: America/Sao_Paulo
+      - interval: 86400
+        anchor_date: "2021-01-01T05:00:00"
+        timezone: America/Sao_Paulo
+        active: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Novos Recursos**
  * Adicionado agendamento automático diário para o fluxo, com horário baseado no fuso de São Paulo.

* **Alterações**
  * O fluxo deixou de iniciar automaticamente o processo de despacho do CadÚnico a partir deste script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->