### PR TITLE
Refactor: security fix, dead code removal, and resilience improvements

### DIFF
--- a/pipelines/rj_crm__disparo_template/prefect.yaml
+++ b/pipelines/rj_crm__disparo_template/prefect.yaml
@@ -23,8 +23,7 @@ deployments:
 
   - name: rj-crm--disparo-template-sf--staging
     version: '{{ build-image.tag }}'
-    entrypoint: 
-      pipelines/rj_crm__disparo_template/flow.py:rj_crm__disparo_template_sf
+    entrypoint: pipelines/rj_crm__disparo_template/flow.py:rj_crm__disparo_template_sf
     work_pool:
       name: default-pool
       work_queue_name: default

--- a/pipelines/rj_crm__salesforce_api/flow.py
+++ b/pipelines/rj_crm__salesforce_api/flow.py
@@ -30,7 +30,6 @@ from pipelines.rj_crm__salesforce_api.tasks import build_dataframe, fetch_sfmc_r
 from pipelines.rj_crm__disparo_template.utils.tasks import create_date_partitions
 
 
-# force deployyy
 @flow(log_prints=True)
 def rj_crm__salesforce_api(
     route: str,
@@ -82,14 +81,6 @@ def rj_crm__salesforce_api(
 
     rename_current_flow_run_task(new_name=f"sfmc_api__{http_method}__{table_id}")
     inject_bd_credentials_task(environment="prod")
-
-    # Debug: lista todas as keys disponíveis no ambiente (K8s Secret montado)
-    # Útil para confirmar quais variáveis do Infisical chegaram ao pod
-    all_env_keys = sorted(os.environ.keys())
-    print(f"[SFMC] Todas as keys no ambiente do pod ({len(all_env_keys)} total):")
-    print("\n".join(all_env_keys))
-    sfmc_keys = [k for k in all_env_keys if k.startswith("sfmc_")]
-    print(f"[SFMC] Keys com prefixo 'sfmc_': {sfmc_keys}")
 
     # 1. Chamar a rota da SFMC REST API (GET ou POST, com paginação automática)
     records = fetch_sfmc_route(

--- a/pipelines/rj_smas__api_datametrica_agendamentos/flow.py
+++ b/pipelines/rj_smas__api_datametrica_agendamentos/flow.py
@@ -4,8 +4,6 @@ from iplanrio.pipelines_utils.dbt import execute_dbt_task
 from iplanrio.pipelines_utils.env import inject_bd_credentials_task
 from iplanrio.pipelines_utils.prefect import rename_current_flow_run_task
 from prefect import flow
-from prefect.deployments import run_deployment
-# from pipelines.rj_smas__disparo_cadunico.flow import rj_smas__disparo_cadunico
 
 from pipelines.rj_smas__api_datametrica_agendamentos.constants import (
     DatametricaConstants,
@@ -88,6 +86,11 @@ def rj_smas__api_datametrica_agendamentos(
     # Converter para DataFrame
     df = convert_agendamentos_to_dataframe(processed_data)
 
+    # Encerrar o flow sem erro se não houver agendamentos para a data
+    if df.empty:
+        print(f"Nenhum agendamento encontrado para a data {target_date}. Encerrando sem upload.")
+        return
+
     # Criar partições por data
     partitions_path = create_date_partitions(
         dataframe=df,
@@ -107,33 +110,3 @@ def rj_smas__api_datametrica_agendamentos(
     if materialize_after_dump:
         dbt_select = "raw_cadunico_agendamentos"
         execute_dbt_task(select=dbt_select, target="prod")
-    
-    print("\n\n******* Triggering cadunico dispatch flow... *******")
-
-    cadunico_params = {
-        "campaign_name": "confirma_agendamento_cadunico_prod_v2",
-        "data_extension_filename": "whatsapp_cadunico",
-        "de_columns": ["nome_sobrenome", "unidade_cras", "data", "hora", "endereco"],
-        "dataset_id": "brutos_salesforce",
-        "table_id": "disparos_efetuados",
-        "dump_mode": "append",
-        "test_mode": False,
-        "chunk_size": 1000,
-        "sleep_minutes": 1,
-        "flow_environment": "production",
-        # "query_processor_name": "skip_weekends",
-        # "days_ahead": "2",
-        "filter_dispatched_phones_or_cpfs": None,
-        "filter_duplicated_phones": False,
-        "filter_duplicated_cpfs": True,
-        "whitelist_percentage": 0,
-        "infisical_secret_path": "/crm_disparo_template",
-        "whitelist_environment": "production",
-        "query_file": "queries/confirma_agendamento_cadunico.sql",
-    }
-    # run_deployment(
-    #     name="rj-crm--disparo-template-sf/rj-crm--disparo-template-sf--prod",
-    #     parameters=cadunico_params,
-    #     timeout=0,
-    # )
-    # force deploy deploy

--- a/pipelines/rj_smas__api_datametrica_agendamentos/tasks.py
+++ b/pipelines/rj_smas__api_datametrica_agendamentos/tasks.py
@@ -6,7 +6,7 @@ Tasks migradas do Prefect 1.4 para 3.0 - SMAS API Datametrica Agendamentos
 # pylint: disable=invalid-name
 # flake8: noqa: E501
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import pandas as pd
 import requests
@@ -83,23 +83,19 @@ def get_datametrica_credentials(
 
 
 @task
-def fetch_agendamentos_from_api(credentials: Dict[str, str], date: Optional[str] = None) -> List[Dict[str, Any]]:
+def fetch_agendamentos_from_api(credentials: Dict[str, str], date: str) -> List[Dict[str, Any]]:
     """
     Busca os agendamentos da API da Datametrica usando proxy brasileiro.
 
     Args:
         credentials: Dict com 'url', 'token', 'proxy_url' e 'proxy_token'
-        date: Data no formato YYYY-MM-DD. Se None, usa lógica padrão (dia seguinte - DEPRECATED, usar calculate_target_date).
+        date: Data no formato YYYY-MM-DD. Sempre obrigatória — use calculate_target_date() para obter a data correta.
 
     Returns:
         Lista de dicionários com os dados dos agendamentos
     """
     # Build Datametrica URL
     base_url = credentials["url"].rstrip("/")
-    if date is None:
-        from datetime import datetime, timedelta
-
-        date = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d")
     datametrica_url = f"{base_url}/{date}"
 
     # Build proxy URL
@@ -226,4 +222,4 @@ def convert_agendamentos_to_dataframe(
     log(f"DataFrame criado com {len(df)} registros e {len(df.columns)} colunas")
 
     return df
-#force deploy
+


### PR DESCRIPTION
### Context

This PR was opened after a post-merge audit of PRs #299, #300, and #301. Those PRs
fixed urgent production issues (Salesforce API timeouts, deployment slug length limits,
dispatch pipeline migration) but left behind security risks, dead code, and a crash-
inducing bug. This PR addresses all of them.

---

### Changes

---

#### 1. [SECURITY] Remove environment variable dump from `rj_crm__salesforce_api/flow.py`

**Severity: High**

The following debug block was present in the production flow and executed on every
scheduled run (5 times per workday, Mon–Fri):

```python
all_env_keys = sorted(os.environ.keys())
print(f"[SFMC] Todas as keys no ambiente do pod ({len(all_env_keys)} total):")
print("\n".join(all_env_keys))
sfmc_keys = [k for k in all_env_keys if k.startswith("sfmc_")]
print(f"[SFMC] Keys com prefixo 'sfmc_': {sfmc_keys}")
```

**What it exposed:**
This block printed the names of all environment variables in the Kubernetes pod to
the Prefect UI log stream, visible to anyone with Prefect UI access. The pod environment
includes variables injected from the Kubernetes Secret `prefect-jobs-crm-registry-secrets`,
which holds Salesforce Marketing Cloud credentials (`API_SFMC_CLIENT_ID`,
`API_SFMC_CLIENT_SECRET`, `API_SFMC_AUTH_URL`, `API_SFMC_REST_BASE_URL`) plus any
other infisical-injected keys at path `/api-sfmc`.

**What it did NOT expose:**
The values of those variables. Only key names were printed.

**Risk:**
Exposing key names leaks the infrastructure topology (what credentials exist, how
they are named, what external services are connected). This is useful information for
an attacker mapping the system. It also had a secondary defect: the debug filter
`k.startswith("sfmc_")` would never match, since the actual keys are prefixed with
`API_SFMC_`, making the debug output actively misleading when investigating auth
failures.

**Fix:** The entire debug block was removed. The `import os` was retained because
`os.path.exists` and `os.walk` are still used later in the same flow.

Also removed: leftover `# force deployyy` comment above the `@flow` decorator, a
remnant from a previous force-deploy workaround.

---

#### 2. [BUG] Remove dead dispatch block from `rj_smas__api_datametrica_agendamentos/flow.py`

**Severity: Critical (misleading)**

A block that was intentionally disabled in commit `c8ef5d0` ("turn off cadunico
dispatch from api datametrica agendamento flow") was left with its surrounding code
still active:

```python
# This print ran on every execution:
print("\n\n******* Triggering cadunico dispatch flow... *******")

# This dict was built but never used:
cadunico_params = { "campaign_name": "confirma_agendamento_cadunico_prod_v2", ... }

# The actual call was commented out:
# run_deployment(
#     name="rj-crm--disparo-template-sf/rj-crm--disparo-template-sf--prod",
#     parameters=cadunico_params,
#     timeout=0,
# )
```

On every production run, the Prefect log would show "Triggering cadunico dispatch
flow..." while no dispatch was actually triggered. Anyone monitoring logs would
believe CadUnico beneficiaries were being notified of their appointments when they
were not.

**Why the `run_deployment` was disabled:** The pipeline was being migrated from the
old Wetalkie-based dispatch system to the new Salesforce template system
(`rj_crm__disparo_template`). The CadUnico campaign (`confirma_agendamento_cadunico_prod_v2`)
now has its own independent schedule in `rj_crm__disparo_template/prefect.yaml`
(confirmed in PR #301 with `active: false` — not yet activated, but properly defined).
The chained call is no longer the intended architecture.

**Fix:** Removed the `print`, the `cadunico_params` dict, the commented-out
`run_deployment` call, the `# force deploy deploy` trailing comment, and the unused
`from prefect.deployments import run_deployment` import.

---

#### 3. [BUG] Handle empty API response in `rj_smas__api_datametrica_agendamentos`

**Severity: High**

When the Datametrica API returns zero appointments for a given date (e.g., a public
holiday or a date with no bookings), the pipeline crashed with an unhandled `KeyError`.

**Crash path:**
```
fetch_agendamentos_from_api()  →  returns []
transform_agendamentos_data([])  →  returns []
convert_agendamentos_to_dataframe([])  →  pd.DataFrame([])  (no columns)
create_date_partitions(df, partition_column="data_hora")
  →  df["data_hora"]  →  KeyError: 'data_hora'
```

An empty DataFrame has no columns at all. Accessing any column by name raises
`KeyError`. This caused the flow to be marked as `Failed` in Prefect and triggered
failure alerts, even though an empty result is a perfectly normal business event.

**Fix:** Added an early return in the flow immediately after `convert_agendamentos_to_dataframe`:

```python
if df.empty:
    print(f"Nenhum agendamento encontrado para a data {target_date}. Encerrando sem upload.")
    return
```

The flow now completes successfully with a clear log message. No upload is attempted,
no dbt run is triggered, and no failure alert is generated.

---

#### 4. [REFACTOR] Remove deprecated fallback date logic from `fetch_agendamentos_from_api`

**Severity: Low**

The task `fetch_agendamentos_from_api` had a fallback for when `date=None`:

```python
if date is None:
    from datetime import datetime, timedelta
    date = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d")
```

This fallback was labeled `DEPRECATED` in the docstring from the very first commit
that introduced it (`afc7586`). The flow always passes a date obtained from
`calculate_target_date()` (which returns `+2 days` on normal days, `+4 days` on
Thursday/Friday). The fallback would return `+1 day` — the wrong date — if it ever
fired.

There are no other callers of `fetch_agendamentos_from_api` in the codebase. The
`date` parameter is now typed as `str` (non-optional), making the contract explicit
and eliminating the silent wrong-date risk. The unused `Optional` import was also
removed.

---

#### 5. [BUG] Fix broken `entrypoint` in `rj_crm__disparo_template/prefect.yaml` (staging)

**Severity: Critical (deployment failure)**

PR #301 introduced a line break inside the `entrypoint` value of the staging
deployment:

```yaml
# broken — introduced by PR #301
entrypoint:
  pipelines/rj_crm__disparo_template/flow.py:rj_crm__disparo_template_sf

# correct — how prod was already defined
entrypoint: pipelines/rj_crm__disparo_template/flow.py:rj_crm__disparo_template_sf
```

In YAML, a key with no value on the same line is parsed as `null`. Prefect would
read `entrypoint: null` and fail the staging deployment with a missing or invalid
entrypoint error. This would have broken every staging deploy of
`rj_crm__disparo_template` until fixed.

**Fix:** Restored the entrypoint to a single line, matching the prod deployment.

---

#### 6. [CLEANUP] Remove `# force deploy` comments from production files

Commits `247c3bc` and `a0aa083` added dummy comments to production Python files as a
workaround to trigger CI/CD redeployment (the deploy script only redeploys pipelines
with changed files). These are now removed:

- `# force deployyy` from `rj_crm__salesforce_api/flow.py`
- `# force deploy deploy` from `rj_smas__api_datametrica_agendamentos/flow.py` (removed as part of fix #2)
- `#force deploy` from `rj_smas__api_datametrica_agendamentos/tasks.py`

**Note for the team:** The GitHub Actions workflow already supports a clean alternative.
Use the manual `workflow_dispatch` trigger with `force_deploy: true` instead of adding
dummy commits to source files.

---

### Files changed

| File | Changes |
|---|---|
| `pipelines/rj_crm__salesforce_api/flow.py` | Removed env dump debug block (security); removed `# force deployyy` comment |
| `pipelines/rj_crm__disparo_template/prefect.yaml` | Fixed broken staging `entrypoint` |
| `pipelines/rj_smas__api_datametrica_agendamentos/flow.py` | Removed dead dispatch block and misleading print; added empty DataFrame guard; removed unused import |
| `pipelines/rj_smas__api_datametrica_agendamentos/tasks.py` | Removed deprecated `+1 day` fallback; `date` parameter now typed as `str`; removed unused `Optional` import; removed `#force deploy` comment |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correções**
  * Corrigido o direcionamento de um fluxo de staging para o ponto de entrada correto.
  * Fluxos agora encerram sem upload quando não há dados disponíveis.
  * A data das consultas de agendamentos passou a ser informada explicitamente.

* **Melhorias**
  * Removidas mensagens e saídas de depuração desnecessárias durante a execução.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->