### PR TITLE
feat: sync do disparo do cadunico com a atualização da api da datamétrica

### DIFF
--- a/pipelines/rj_smas__api_datametrica_agendamentos/flow.py
+++ b/pipelines/rj_smas__api_datametrica_agendamentos/flow.py
@@ -112,13 +112,15 @@ def rj_smas__api_datametrica_agendamentos(
 
     cadunico_params = {
         "campaign_name": "confirma_agendamento_cadunico_prod_v2",
-        "data_extension_filename": "whatsapp_cadunico",
+        "query_replacements": {"days_ahead_placeholder": 2, "nome_hsm_placeholder": "confirma_agendamento_cadunico_prod_v2",
+            "intervalo_filtro_disparados": 1, "id_hsm_legado_placeholder": 101},
+        "data_extension_filename": "whatsapp_cadunico_",
         "de_columns": ["nome_sobrenome", "unidade_cras", "data", "hora", "endereco"],
         "dataset_id": "brutos_salesforce",
         "table_id": "disparos_efetuados",
         "dump_mode": "append",
         "test_mode": False,
-        "chunk_size": 1000,
+        # "chunk_size": 1000,
         "sleep_minutes": 1,
         "flow_environment": "production",
         # "query_processor_name": "skip_weekends",
@@ -129,11 +131,82 @@ def rj_smas__api_datametrica_agendamentos(
         "whitelist_percentage": 0,
         "infisical_secret_path": "/crm_disparo_template",
         "whitelist_environment": "production",
-        "query_file": "queries/confirma_agendamento_cadunico.sql",
+        "query": """WITH
+                    segmentacao_original AS (
+                        SELECT
+                            LPAD(CAST(cpf AS STRING), 11, '0') AS cpf,
+                            `rj-crm-registry.udf.VALIDATE_AND_FORMAT_CELLPHONE`(
+                                REGEXP_REPLACE(telefone, r'[^\d]', '')
+                            ) AS celular_disparo,
+                            INITCAP(
+                                IF(
+                                    ARRAY_LENGTH(SPLIT(nome_completo, ' ')) > 1,
+                                    CONCAT(
+                                        SPLIT(nome_completo, ' ')[SAFE_OFFSET(0)],
+                                        ' ',
+                                        SPLIT(nome_completo, ' ')[SAFE_OFFSET(ARRAY_LENGTH(SPLIT(nome_completo, ' ')) - 1)]
+                                    ),
+                                    nome_completo
+                                )
+                            ) AS nome_sobrenome,
+                            unidade_nome AS unidade_cras,
+                            CONCAT(unidade_endereco, ' - ', unidade_bairro) AS endereco,
+                            FORMAT_DATETIME('%d/%m/%Y', CAST(data_hora AS DATETIME)) AS data,
+                            FORMAT_DATETIME('%H:%M', CAST(data_hora AS DATETIME)) AS hora
+                        FROM `rj-iplanrio.brutos_data_metrica_staging.cadunico_agendamentos`
+                        WHERE
+                            DATE(CAST(data_hora AS DATETIME)) = DATE_ADD(
+                                CURRENT_DATE('America/Sao_Paulo'),
+                                INTERVAL CAST({days_ahead_placeholder} AS int64) DAY
+                            )
+                    ),
+
+                    filtra_disparados AS (
+                        -- verifica se esse cpf já recebeu essa mesma mensagem nos últimos x dias
+                        SELECT segmentacao_original.*
+                        FROM segmentacao_original
+                        LEFT JOIN `rj-crm-registry.brutos_salesforce.status_disparo` sd
+                            ON sd.cpf = segmentacao_original.cpf
+                            AND sd.nome_hsm = '{nome_hsm_placeholder}'
+                            AND sd.envio_datahora >= DATETIME_SUB(
+                                CURRENT_DATETIME('America/Sao_Paulo'),
+                                INTERVAL {intervalo_filtro_disparados} DAY
+                            )
+                            AND sd.data_particao >= DATE_SUB(CURRENT_DATE(), INTERVAL {intervalo_filtro_disparados} DAY)
+                            AND sd.indicador_quarentena = FALSE
+                        LEFT JOIN `rj-crm-registry.crm_whatsapp.telefone_disparado` td
+                            ON td.contato_telefone = segmentacao_original.celular_disparo
+                            AND td.id_hsm = CAST({id_hsm_legado_placeholder} AS STRING)
+                            AND td.data_particao >= DATE_SUB(CURRENT_DATE(), INTERVAL {intervalo_filtro_disparados} DAY)
+                        WHERE sd.cpf IS NULL AND td.contato_telefone IS NULL
+                    ),
+
+                    filtra_celulares_sem_whats AS (
+                        -- remove telefones em quarentena ou com qualidade inválida
+                        SELECT DISTINCT s.*
+                        FROM filtra_disparados AS s
+                        LEFT JOIN `rj-crm-registry.intermediario_rmi_telefones.int_telefone` AS tel
+                            ON s.celular_disparo = tel.telefone_numero_completo
+                        LEFT JOIN UNNEST(tel.consentimento) AS c
+                        WHERE
+                            (c.indicador_quarentena = FALSE AND tel.telefone_qualidade != 'INVALIDO')
+                            OR tel.telefone_numero_completo IS NULL
+                    )
+
+                    SELECT
+                        celular_disparo AS telefone,
+                        cpf AS SubscriberKey,
+                        cpf AS externalId,
+                        nome_sobrenome,
+                        unidade_cras,
+                        data,
+                        hora,
+                        endereco
+                    FROM filtra_celulares_sem_whats
+                    WHERE celular_disparo IS NOT NULL"""
     }
-    # run_deployment(
-    #     name="rj-crm--disparo-template-sf/rj-crm--disparo-template-sf--prod",
-    #     parameters=cadunico_params,
-    #     timeout=0,
-    # )
-    # force deploy deploy
+    run_deployment(
+        name="rj-crm--disparo-template-sf/rj-crm--disparo-template-sf--prod",
+        parameters=cadunico_params,
+        timeout=0,
+    )

--- a/pipelines/rj_smas__api_datametrica_agendamentos/flow.py
+++ b/pipelines/rj_smas__api_datametrica_agendamentos/flow.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
 from iplanrio.pipelines_utils.bd import create_table_and_upload_to_gcs_task
 from iplanrio.pipelines_utils.dbt import execute_dbt_task
 from iplanrio.pipelines_utils.env import inject_bd_credentials_task
@@ -76,7 +79,9 @@ def rj_smas__api_datametrica_agendamentos(
     credentials = get_datametrica_credentials(infisical_secret_path=infisical_secret_path)
 
     # Calcular data target baseada na regra de negócio (a menos que date seja fornecido explicitamente)
+    today_sp = datetime.now(ZoneInfo("America/Sao_Paulo")).date()
     target_date = date if date is not None else calculate_target_date()
+    days_ahead = (datetime.strptime(target_date, "%Y-%m-%d").date() - today_sp).days
 
     # Buscar dados da API
     raw_data = fetch_agendamentos_from_api(credentials=credentials, date=target_date)
@@ -116,7 +121,7 @@ def rj_smas__api_datametrica_agendamentos(
 
     cadunico_params = {
         "campaign_name": "confirma_agendamento_cadunico_prod_v2",
-        "query_replacements": {"days_ahead_placeholder": 2, "nome_hsm_placeholder": "confirma_agendamento_cadunico_prod_v2",
+        "query_replacements": {"days_ahead_placeholder": days_ahead, "nome_hsm_placeholder": "confirma_agendamento_cadunico_prod_v2",
             "intervalo_filtro_disparados": 1, "id_hsm_legado_placeholder": 101},
         "data_extension_filename": "whatsapp_cadunico_",
         "de_columns": ["nome_sobrenome", "unidade_cras", "data", "hora", "endereco"],

--- a/pipelines/rj_smas__api_datametrica_agendamentos/flow.py
+++ b/pipelines/rj_smas__api_datametrica_agendamentos/flow.py
@@ -214,3 +214,4 @@ def rj_smas__api_datametrica_agendamentos(
         parameters=cadunico_params,
         timeout=0,
     )
+    # force deploy

--- a/pipelines/rj_smas__api_datametrica_agendamentos/prefect.yaml
+++ b/pipelines/rj_smas__api_datametrica_agendamentos/prefect.yaml
@@ -64,7 +64,7 @@ deployments:
     #  - cron: "0 8 * * *"  # Diariamente às 10:00
     #    timezone: America/Sao_Paulo
       - interval: 86400
-        anchor_date: "2021-01-01T05:00:00"
+        anchor_date: "2021-01-01T11:00:00"
         timezone: America/Sao_Paulo
         active: true
         slug: daily-atualizacao-api-datametrica-agend-cadunico

--- a/pipelines/rj_smas__api_datametrica_agendamentos/tasks.py
+++ b/pipelines/rj_smas__api_datametrica_agendamentos/tasks.py
@@ -8,6 +8,8 @@ Tasks migradas do Prefect 1.4 para 3.0 - SMAS API Datametrica Agendamentos
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
+import json
+
 import pandas as pd
 import requests
 import urllib3
@@ -158,6 +160,8 @@ def transform_agendamentos_data(
     agendamentos = []
     for data in agendamentos_data:
         try:
+            if isinstance(data, str):
+                data = json.loads(data)
             agendamento = {
                 "id": data["id"],
                 "id_capacidade": data["id_capacidade"],

--- a/pipelines/rj_smas__api_datametrica_agendamentos/tasks.py
+++ b/pipelines/rj_smas__api_datametrica_agendamentos/tasks.py
@@ -108,9 +108,6 @@ def fetch_agendamentos_from_api(credentials: Dict[str, str], date: Optional[str]
     proxy_url = f"{credentials['proxy_url'].rstrip('/')}/?url={datametrica_url}"
 
     log("Buscando agendamentos via proxy brasileiro")
-    log(f"Datametrica URL: {datametrica_url}")
-    log(f"Proxy URL: {proxy_url}")
-    log(f"Token (primeiros 10 chars): {credentials['token'][:10]}...")
 
     # Headers incluindo o token do proxy e os headers originais da Datametrica
     headers = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Novos Recursos**
  - Após a atualização dos agendamentos, o disparo da campanha pode ser iniciado automaticamente quando a opção estiver habilitada, disparando um novo deployment adicional.
- **Correções**
  - Ajustado o destino dos dados no ambiente de staging.
  - Atualizada a regra de datas para considerar 2 dias à frente (com tratamento específico para quinta e sexta).
- **Segurança**
  - Reduzida a exposição de informações sensíveis nos registros de execução.
- **Mudanças**
  - O processamento agora aceita itens retornados em formato JSON (quando necessário).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->