### PR TITLE
fix: flow de agendamento cadunico não roda aos fins de semana

### DIFF
--- a/pipelines/rj_crm__disparo_template/prefect.yaml
+++ b/pipelines/rj_crm__disparo_template/prefect.yaml
@@ -303,7 +303,7 @@ deployments:
             as int64);\n"
       - cron: "0 13 * * *"
         timezone: America/Sao_Paulo
-        active: true
+        active: false
         slug: daily-pgm-divida-ativa-lembrete-prod-v1
         flow_run_name: pgm-divida-ativa-lembrete
         parameters:
@@ -424,7 +424,7 @@ deployments:
             pagas\n"
       - cron: "0 13 * * *"
         timezone: America/Sao_Paulo
-        active: true
+        active: false
         slug: daily-pgm-divida-ativa-confirma-pgto-prod-v1
         flow_run_name: pgm-divida-ativa-confirma-pgto-prod-v1
         parameters:
@@ -522,7 +522,7 @@ deployments:
             from remove_optout\nwhere rn=1\n"
       - cron: "0 10 * * *"
         timezone: America/Sao_Paulo
-        active: true
+        active: false
         slug: daily-sms-puerpera-confirma-agendamento
         flow_run_name: sms-puerpera-confirma-agendamento
         parameters:
@@ -629,7 +629,7 @@ deployments:
             final\n    where celular_disparo is not null\n"
       - cron: "0 14 * * *"
         timezone: America/Sao_Paulo
-        active: true
+        active: false
         slug: daily-sms-puerperas-d0
         flow_run_name: sms-puerperas-d0
         parameters:
@@ -734,7 +734,7 @@ deployments:
             \    where celular_disparo is not null\n"
       - cron: "0 10 * * *"
         timezone: America/Sao_Paulo
-        active: true
+        active: false
         slug: daily-sms-puerperas-d1-d3-d5-d10-d13-d16-d19
         flow_run_name: sms-puerperas-d1-d3-d5-d10-d13-d16-d19
         parameters:
@@ -869,7 +869,7 @@ deployments:
             AS others\nfrom final\nwhere celular_disparo is not null\n"
       - cron: "0 10 * * *"
         timezone: America/Sao_Paulo
-        active: true
+        active: false
         slug: daily-sms-puerperas-d7-d22
         flow_run_name: sms-puerperas-d7-d22
         parameters:
@@ -996,7 +996,7 @@ deployments:
             AS others\nfrom final\nwhere celular_disparo is not null\n"
       - cron: "0 10 * * *"
         timezone: America/Sao_Paulo
-        active: true
+        active: false
         slug: daily-sms-puerperas-d25-d28-d34
         flow_run_name: sms-puerperas-d25-d28-d34
         parameters:
@@ -1125,7 +1125,7 @@ deployments:
             AS others\nfrom final\nwhere celular_disparo is not null\n"
       - cron: "0 10 * * *"
         timezone: America/Sao_Paulo
-        active: true
+        active: false
         slug: daily-sms-puerperas-d40
         flow_run_name: sms-puerperas-d40
         parameters:
@@ -1722,9 +1722,9 @@ deployments:
             AS cc_wt_solicitacao,\n        canal_tratado AS cc_wt_canal,\n       \
             \ CAST(numero_protocolo AS STRING) AS protocolo,\n        status_demanda_tratado
             AS STATUS_DEMANDA\n    FROM dados_finais;\n"
-      - cron: "0 13 * * *"
+      - cron: "0 13 * * *"  
         timezone: America/Sao_Paulo
-        active: true
+        active: false
         slug: daily-pgm-divida-ativa-prod
         flow_run_name: pgm-divida-ativa
         parameters:

--- a/pipelines/rj_crm__disparo_template/prefect.yaml
+++ b/pipelines/rj_crm__disparo_template/prefect.yaml
@@ -1134,6 +1134,7 @@ deployments:
             nome_hsm_placeholder: smspuerperasdisparo152
             nome_hsm_anterior_placeholder: smspuerperasdisparo25
             id_hsm_anterior_legado_placeholder: 610
+            id_hsm_legado_placeholder": 598
             pesquisa_id: "Pesquisa 7"
             datas_internacao: "DATE_ADD(DATE(data_alta_internacao), INTERVAL 40 DAY)"
             intervalo_filtro_disparados: 1

--- a/pipelines/rj_crm__disparo_template/prefect.yaml
+++ b/pipelines/rj_crm__disparo_template/prefect.yaml
@@ -303,7 +303,7 @@ deployments:
             as int64);\n"
       - cron: "0 13 * * *"
         timezone: America/Sao_Paulo
-        active: false
+        active: true
         slug: daily-pgm-divida-ativa-lembrete-prod-v1
         flow_run_name: pgm-divida-ativa-lembrete
         parameters:
@@ -424,7 +424,7 @@ deployments:
             pagas\n"
       - cron: "0 13 * * *"
         timezone: America/Sao_Paulo
-        active: false
+        active: true
         slug: daily-pgm-divida-ativa-confirma-pgto-prod-v1
         flow_run_name: pgm-divida-ativa-confirma-pgto-prod-v1
         parameters:
@@ -522,7 +522,7 @@ deployments:
             from remove_optout\nwhere rn=1\n"
       - cron: "0 10 * * *"
         timezone: America/Sao_Paulo
-        active: false
+        active: true
         slug: daily-sms-puerpera-confirma-agendamento
         flow_run_name: sms-puerpera-confirma-agendamento
         parameters:
@@ -629,7 +629,7 @@ deployments:
             final\n    where celular_disparo is not null\n"
       - cron: "0 14 * * *"
         timezone: America/Sao_Paulo
-        active: false
+        active: true
         slug: daily-sms-puerperas-d0
         flow_run_name: sms-puerperas-d0
         parameters:
@@ -734,7 +734,7 @@ deployments:
             \    where celular_disparo is not null\n"
       - cron: "0 10 * * *"
         timezone: America/Sao_Paulo
-        active: false
+        active: true
         slug: daily-sms-puerperas-d1-d3-d5-d10-d13-d16-d19
         flow_run_name: sms-puerperas-d1-d3-d5-d10-d13-d16-d19
         parameters:
@@ -869,7 +869,7 @@ deployments:
             AS others\nfrom final\nwhere celular_disparo is not null\n"
       - cron: "0 10 * * *"
         timezone: America/Sao_Paulo
-        active: false
+        active: true
         slug: daily-sms-puerperas-d7-d22
         flow_run_name: sms-puerperas-d7-d22
         parameters:
@@ -996,7 +996,7 @@ deployments:
             AS others\nfrom final\nwhere celular_disparo is not null\n"
       - cron: "0 10 * * *"
         timezone: America/Sao_Paulo
-        active: false
+        active: true
         slug: daily-sms-puerperas-d25-d28-d34
         flow_run_name: sms-puerperas-d25-d28-d34
         parameters:
@@ -1125,7 +1125,7 @@ deployments:
             AS others\nfrom final\nwhere celular_disparo is not null\n"
       - cron: "0 10 * * *"
         timezone: America/Sao_Paulo
-        active: false
+        active: true
         slug: daily-sms-puerperas-d40
         flow_run_name: sms-puerperas-d40
         parameters:
@@ -2852,7 +2852,7 @@ deployments:
             WHERE celular_disparo IS NOT NULL\n"
       - cron: "0 12 * * *"
         timezone: America/Sao_Paulo
-        active: true
+        active: false
         slug: daily-smas-cartaopic-evento
         flow_run_name: smas-cartaopic-evento
         parameters:

--- a/pipelines/rj_crm__disparo_template/prefect.yaml
+++ b/pipelines/rj_crm__disparo_template/prefect.yaml
@@ -1134,7 +1134,7 @@ deployments:
             nome_hsm_placeholder: smspuerperasdisparo152
             nome_hsm_anterior_placeholder: smspuerperasdisparo25
             id_hsm_anterior_legado_placeholder: 610
-            id_hsm_legado_placeholder": 598
+            id_hsm_legado_placeholder: 598
             pesquisa_id: "Pesquisa 7"
             datas_internacao: "DATE_ADD(DATE(data_alta_internacao), INTERVAL 40 DAY)"
             intervalo_filtro_disparados: 1

--- a/pipelines/rj_crm__disparo_template/queries/cadunico_confirma_agendamento.sql
+++ b/pipelines/rj_crm__disparo_template/queries/cadunico_confirma_agendamento.sql
@@ -22,6 +22,7 @@ segmentacao_original AS (
     FROM `rj-iplanrio.brutos_data_metrica_staging.cadunico_agendamentos`
     WHERE
         DATE(CAST(data_hora AS DATETIME)) = DATE_ADD(CURRENT_DATE('America/Sao_Paulo'), INTERVAL CAST({days_ahead_placeholder} AS int64) DAY)
+        AND EXTRACT(DAYOFWEEK FROM current_date("America/Sao_Paulo")) NOT IN (1, 7)
 ),
 
 filtra_disparados AS (

--- a/pipelines/rj_crm__disparo_template/scheduler_sf.yaml
+++ b/pipelines/rj_crm__disparo_template/scheduler_sf.yaml
@@ -29,7 +29,7 @@ schedules:
   # Daily schedule para flow pgm-divida-ativa-prod
   - cron: "0 13 * * *"
     timezone: America/Sao_Paulo
-    active: true
+    active: false
     slug: daily-pgm-divida-ativa-prod
     flow_run_name: pgm-divida-ativa
     parameters:
@@ -436,7 +436,7 @@ schedules:
   # TODO: aponta pra fantasma dev (sem acesso ao rj-iplanrio) - trocar de volta pra queries/ antes de ir pra producao
   - cron: "0 12 * * *"
     timezone: America/Sao_Paulo
-    active: true
+    active: false
     slug: daily-smas-cartaopic-evento
     flow_run_name: smas-cartaopic-evento
     parameters:

--- a/pipelines/rj_smas__api_datametrica_agendamentos/flow.py
+++ b/pipelines/rj_smas__api_datametrica_agendamentos/flow.py
@@ -81,6 +81,11 @@ def rj_smas__api_datametrica_agendamentos(
     # Calcular data target baseada na regra de negócio (a menos que date seja fornecido explicitamente)
     today_sp = datetime.now(ZoneInfo("America/Sao_Paulo")).date()
     target_date = date if date is not None else calculate_target_date()
+
+    if target_date is None:
+        print("Hoje é sábado ou domingo. Encerrando flow sem processamento.")
+        return
+
     days_ahead = (datetime.strptime(target_date, "%Y-%m-%d").date() - today_sp).days
 
     # Buscar dados da API
@@ -105,18 +110,18 @@ def rj_smas__api_datametrica_agendamentos(
         root_folder=root_folder,
     )
 
-    create_table_and_upload_to_gcs_task(
+    upload_result = create_table_and_upload_to_gcs_task(
         data_path=partitions_path,
         dataset_id=dataset_id,
         table_id=table_id,
         dump_mode=dump_mode,
         biglake_table=biglake_table,
     )
+    upload_result.result()
 
     if materialize_after_dump:
         dbt_select = "raw_cadunico_agendamentos"
         execute_dbt_task(select=dbt_select, target="prod")
-    
     print("\n\n******* Triggering cadunico dispatch flow... *******")
 
     cadunico_params = {
@@ -219,4 +224,3 @@ def rj_smas__api_datametrica_agendamentos(
         parameters=cadunico_params,
         timeout=0,
     )
-    # force deploy

--- a/pipelines/rj_smas__api_datametrica_agendamentos/flow.py
+++ b/pipelines/rj_smas__api_datametrica_agendamentos/flow.py
@@ -173,6 +173,7 @@ def rj_smas__api_datametrica_agendamentos(
                                 CURRENT_DATE('America/Sao_Paulo'),
                                 INTERVAL CAST({days_ahead_placeholder} AS int64) DAY
                             )
+                            AND EXTRACT(DAYOFWEEK FROM current_date("America/Sao_Paulo")) NOT IN (1, 7)
                     ),
 
                     filtra_disparados AS (

--- a/pipelines/rj_smas__api_datametrica_agendamentos/flow.py
+++ b/pipelines/rj_smas__api_datametrica_agendamentos/flow.py
@@ -110,14 +110,13 @@ def rj_smas__api_datametrica_agendamentos(
         root_folder=root_folder,
     )
 
-    upload_result = create_table_and_upload_to_gcs_task(
+    create_table_and_upload_to_gcs_task(
         data_path=partitions_path,
         dataset_id=dataset_id,
         table_id=table_id,
         dump_mode=dump_mode,
         biglake_table=biglake_table,
     )
-    upload_result.result()
 
     if materialize_after_dump:
         dbt_select = "raw_cadunico_agendamentos"

--- a/pipelines/rj_smas__api_datametrica_agendamentos/prefect.yaml
+++ b/pipelines/rj_smas__api_datametrica_agendamentos/prefect.yaml
@@ -61,11 +61,8 @@ deployments:
       date: null  # null usa regra de negócio: 2 dias à frente (4 dias em quinta/sexta)
       infisical_secret_path: /api-datametrica
     schedules:
-    #  - cron: "0 8 * * *"  # Diariamente às 10:00
-    #    timezone: America/Sao_Paulo
-      - interval: 86400
-        anchor_date: "2021-01-01T11:00:00"
-        timezone: America/Sao_Paulo
+      - cron: "0 12 * * 1-5"
+        timezone: UTC
         active: true
         slug: daily-atualizacao-api-datametrica-agend-cadunico
         flow_run_name: atualizacao-api-datametrica-agend-cadunico

--- a/pipelines/rj_smas__api_datametrica_agendamentos/tasks.py
+++ b/pipelines/rj_smas__api_datametrica_agendamentos/tasks.py
@@ -22,17 +22,22 @@ from iplanrio.pipelines_utils.logging import log  # pylint: disable=E0611, E0401
 
 
 @task
-def calculate_target_date() -> str:
+def calculate_target_date() -> str | None:
     """
     Calcula a data target baseada na regra de negócio:
+    - Sábado (5) ou Domingo (6): retorna None (flow deve ser encerrado)
     - Dias normais: 2 dias à frente
-    - Quinta-feira (4) e Sexta-feira (5): 4 dias à frente
+    - Quinta-feira (3) e Sexta-feira (4): 4 dias à frente
 
     Returns:
-        str: Data no formato YYYY-MM-DD
+        str: Data no formato YYYY-MM-DD, ou None se for sábado ou domingo
     """
     today = datetime.now()
     weekday = today.weekday()  # 0=Monday, 1=Tuesday, ..., 6=Sunday
+
+    if weekday in [5, 6]:  # Saturday or Sunday
+        log(f"(calculate_target_date) - Fim de semana detectado (weekday={weekday}) - encerrando flow")
+        return None
 
     # Quinta-feira (3) e Sexta-feira (4) em Python weekday (0-indexed, Monday=0)
     if weekday in [3, 4]:  # Thursday and Friday

--- a/pipelines/rj_smas__api_datametrica_agendamentos/tasks.py
+++ b/pipelines/rj_smas__api_datametrica_agendamentos/tasks.py
@@ -7,6 +7,7 @@ Tasks migradas do Prefect 1.4 para 3.0 - SMAS API Datametrica Agendamentos
 # flake8: noqa: E501
 from datetime import datetime, timedelta
 from typing import Any, Dict, List
+from zoneinfo import ZoneInfo
 
 import json
 
@@ -32,7 +33,7 @@ def calculate_target_date() -> str | None:
     Returns:
         str: Data no formato YYYY-MM-DD, ou None se for sábado ou domingo
     """
-    today = datetime.now()
+    today = datetime.now(ZoneInfo("America/Sao_Paulo"))
     weekday = today.weekday()  # 0=Monday, 1=Tuesday, ..., 6=Sunday
 
     if weekday in [5, 6]:  # Saturday or Sunday


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Correções**
  * O processamento agora é interrompido imediatamente em fins de semana, evitando etapas e buscas desnecessárias.
  * Os disparos passam a considerar apenas dias úteis, excluindo sábado e domingo na seleção de agendamentos.
  * Ajustes em logs e mensagens para refletir o novo comportamento.
* **Alterações de Agendamento**
  * O job foi alterado para rodar de segunda a sexta às 12:00 via cron, com timezone em UTC.
  * Rotinas automáticas tiveram ativações/desativações ajustadas e um identificador de template atualizado.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->