### PR TITLE
[crm] Padronização dos dados de destinatários para utilizar telefone e CPF.

### DIFF
--- a/pipelines/rj_crm__disparo_template/constants.py
+++ b/pipelines/rj_crm__disparo_template/constants.py
@@ -32,37 +32,3 @@ class TemplateConstants(Enum):
     DUMP_MODE = "append"
     CHUNK_SIZE = 1000
 
-    # Query principal do CadÚnico
-    QUERY = r"""
-        SELECT
-            TO_JSON_STRING(STRUCT(
-                REGEXP_REPLACE(telefone, r'[^\d]', '') as celular_disparo,
-                STRUCT(
-                    primeiro_nome as NOME,
-                    FORMAT_DATETIME('%d/%m/%Y', DATETIME(data_hora)) as DATA,
-                    FORMAT_DATETIME('%H:%M', DATETIME(data_hora)) as HORA,
-                    unidade_nome as LOCAL,
-                    CONCAT(unidade_endereco, ' - ', unidade_bairro) as ENDERECO
-                ) as vars,
-                cpf as externalId
-            )) as destination_data
-        FROM `rj-smas.brutos_data_metrica_staging.agendamentos_cadunico`
-        WHERE
-            DATE(data_hora) = DATE_ADD(
-            CURRENT_DATE("America/Sao_Paulo"),
-            INTERVAL {days_ahead} DAY)
-            AND telefone NOT IN (
-                SELECT contato_telefone
-                FROM `rj-crm-registry.crm_whatsapp.telefone_sem_whatsapp`
-                WHERE data_atualizacao > DATE_SUB(CURRENT_DATE(), INTERVAL 1 YEAR)
-            )
-            AND telefone IS NOT NULL
-            AND LENGTH(REGEXP_REPLACE(telefone, r'[^\d]', '')) >= 10
-            AND telefone NOT IN (
-                SELECT contato_telefone
-                FROM `rj-crm-registry-dev.patricia__crm_whatsapp.telefone_disparado`
-                WHERE id_hsm = '{hsm_id}'
-                    AND data_particao >= DATE_SUB(CURRENT_DATE(), INTERVAL 15 DAY)
-            )
-        ORDER BY data_hora
-    """

--- a/pipelines/rj_crm__disparo_template/flow.py
+++ b/pipelines/rj_crm__disparo_template/flow.py
@@ -111,6 +111,7 @@ def rj_crm__disparo_template_sf(
     monitor_after_sftp: bool = True,
     monitor_check_interval_minutes: int = 5,
     monitor_max_wait_minutes: int = 40,
+    sftp_remote_path: str = "/Import/",
     debug: bool = True,
 ):
     """
@@ -161,6 +162,7 @@ def rj_crm__disparo_template_sf(
             até monitor_max_wait_minutes. Alerta no Discord se nenhum sucesso for encontrado nesse prazo.
         monitor_check_interval_minutes (int, optional): Intervalo entre checagens do monitoramento. Defaults to 5.
         monitor_max_wait_minutes (int, optional): Tempo máximo de monitoramento antes de alertar. Defaults to 40.
+        sftp_remote_path (str, optional): Diretório remoto no servidor SFTP onde o CSV será depositado. Defaults to "/Import/".
     """
 
     # force deploy
@@ -252,7 +254,7 @@ def rj_crm__disparo_template_sf(
     )
     print(f"[DEBUG] Após filtrar cpfs duplicados:\n{df.head(10).to_dict('records')}") if debug else None
     if df.empty:
-        print("No destinations found after filtering duplicate CPFs. Exiting flow execution.")
+        send_dispatch_no_destinations_found(campaign_name, test_mode)
         return
 
     # Remove telefones cujo último disparo falhou e estão em quarentena
@@ -421,6 +423,7 @@ def rj_crm__disparo_template_sf(
         send_to_sftp(
             csv_path=csv_path,
             infisical_secret_path=infisical_secret_path,
+            sftp_remote_path=sftp_remote_path,
         )
 
         print(f"CSV enviado para SFTP com {len(current_df)} destinatários na tentativa {i+1}.")

--- a/pipelines/rj_crm__disparo_template/flow.py
+++ b/pipelines/rj_crm__disparo_template/flow.py
@@ -336,11 +336,10 @@ def rj_crm__disparo_template_sf(
         # --------------------------------------------------------------------------------------
         # PASSO 1: FILTRO DE SEGURANÇA DA MESMA CAMPANHA
         # --------------------------------------------------------------------------------------
-        # Esse filtro impede que o mesmo CPF receba a MESMA campanha mais de uma vez dentro da
-        # janela configurada (ex: 7 dias) no disparo inicial, ou que o mesmo telefone receba
-        # a campanha nas retentativas.
+        # Esse filtro impede que o mesmo CPF (i==0) ou telefone (i>0) receba a MESMA campanha mais de uma
+        # vez dentro da janela configurada (ex: 7 dias).
         # No primeiro disparo (i == 0):
-        #   - Filtramos sempre por "cpf", garantindo que o CPF não receba a mesma campanha no intervalo.
+        #   - Se for "cpf" ou None (padrão), filtramos por "cpf".
         # No retry (i > 0):
         #   - Filtramos por "telefone" para garantir que o número de retry não recebeu a campanha antes,
         #     permitindo que o mesmo CPF tente um telefone alternativo.

--- a/pipelines/rj_crm__disparo_template/flow.py
+++ b/pipelines/rj_crm__disparo_template/flow.py
@@ -7,9 +7,8 @@ Flow to dispatch templated messages via Salesforce SFTP
 """
 import os
 import time
-from math import ceil
 from pathlib import Path
-import pendulum
+import pandas as pd
 
 from iplanrio.pipelines_utils.bd import create_table_and_upload_to_gcs_task  # pylint: disable=E0611, E0401
 from iplanrio.pipelines_utils.dbt import execute_dbt_task  # pylint: disable=E0611, E0401
@@ -31,17 +30,14 @@ from pipelines.rj_crm__disparo_template.utils.dispatch import (
     check_flow_status,
     create_log_df,
     filter_already_dispatched_phones_or_cpfs,
+    filter_duplicated,
     format_query,
     get_already_dispatched_data,
-    get_destinations,
     get_failed_cpfs,
     get_failed_phones,
     get_retry_destinations,
     monitor_dispatch_status,
     remove_contacts_from_whitelist,
-    remove_duplicate_cpfs,
-    remove_duplicate_phones,
-    remove_failed_phones,
     save_csv_for_sftp,
     send_to_sftp,
 )
@@ -98,6 +94,7 @@ def rj_crm__disparo_template_sf(
     filter_duplicated_phones: bool = True,
     filter_duplicated_cpfs: bool = True,
     filter_failed_phones: bool = False,
+    dispatch_interval_days: int = 1,
     sleep_minutes: int | None = 5,
     materialization_sleep_minutes: int | None = 20,
     max_dispatch_retries: int = 0,
@@ -114,6 +111,7 @@ def rj_crm__disparo_template_sf(
     monitor_after_sftp: bool = True,
     monitor_check_interval_minutes: int = 5,
     monitor_max_wait_minutes: int = 40,
+    debug: bool = True,
 ):
     """
     Orchestrates the dispatch of templated messages via Salesforce SFTP.
@@ -138,7 +136,7 @@ def rj_crm__disparo_template_sf(
             query instead of passing the raw SQL in `query`. Takes precedence over `query`.
         query_processor_name (str, optional): Name of the query processor.
         query_replacements (dict, optional): Replacements for query placeholders.
-        filter_dispatched_phones_or_cpfs (str, optional): None, "cpf" or "phone_number". Defaults to "cpf".
+        filter_dispatched_phones_or_cpfs (str, optional): None, "cpf" or "telefone". Defaults to "cpf".
         filter_duplicated_phones (bool, optional): Remove duplicate phones. Defaults to True.
         filter_duplicated_cpfs (bool, optional): Remove duplicate CPFs. Defaults to True.
         filter_failed_phones (bool, optional): Remove phones that failed in last dispatch. Defaults to False.
@@ -147,7 +145,7 @@ def rj_crm__disparo_template_sf(
         infisical_secret_path (str, optional): Infisical path for SFTP credentials. Defaults to "/sftp".
         de_columns (list[str], optional): Lista de campos (além de telefone/SubscriberKey) que a
             Data Extension espera. Quando informada, o CSV enviado ao SFTP é restrito a essas
-            colunas — qualquer coluna de controle interno da query (ex.: 'others', 'externalId')
+            colunas — qualquer coluna de controle interno da query (ex.: 'others', 'cpf')
             é descartada antes do envio.
         csv_separator (str, optional): Delimitador do CSV enviado ao SFTP. Defaults to ";".
         sftp_remote_path (str, optional): Remote directory on the SFTP server. Defaults to "/".
@@ -177,12 +175,6 @@ def rj_crm__disparo_template_sf(
     rename_flow_run = rename_current_flow_run_task(new_name=f"{table_id}_{dataset_id}")  # pylint: disable=unused-variable
     crd = inject_bd_credentials_task(environment="prod")  # noqa  # pylint: disable=unused-variable
 
-    validated_campaign = validate_campaign_name(
-        campaign_name=campaign_name,
-        billing_project_id=billing_project_id,
-        bucket_name=billing_project_id,
-    )
-
     flow_status = check_flow_status(
         flow_environment=flow_environment,
         billing_project_id=billing_project_id,
@@ -192,7 +184,13 @@ def rj_crm__disparo_template_sf(
     if flow_status is None:
         print("Ending flow due to inactive status.")
         return
-    elif validated_campaign is None:
+
+    validated_campaign = validate_campaign_name(
+        campaign_name=campaign_name,
+        billing_project_id=billing_project_id,
+        bucket_name=billing_project_id,
+    )
+    if validated_campaign is None:
         print(f"Ending flow due to invalid campaign name: {campaign_name} does not exist in table rj-crm-registry.brutos_salesforce.jornada")
         return
 
@@ -207,6 +205,11 @@ def rj_crm__disparo_template_sf(
         )
     else:
         query_complete = query
+
+    if query_complete is None:
+        print("Query retornou None (ex: processador de fim de semana). Encerrando flow.")
+        return
+
     print(f"\n⚠️  Query dispatch:\n{query_complete}")
 
     # O disparo SF trabalha com o DataFrame plano retornado pela query.
@@ -224,31 +227,45 @@ def rj_crm__disparo_template_sf(
     if "LOCALE" not in df.columns:
         df["LOCALE"] = "BR"
 
-    # Valida colunas obrigatórias para o log SF: SubscriberKey e telefone.
+    print(f"[DEBUG] Colunas antes do rename: {list(df.columns)}")
+
+    # Padroniza a coluna de CPF para 'cpf' caso as queries antigas ainda retornem 'SubscriberKey'
+    if "SubscriberKey" in df.columns and "cpf" not in df.columns:
+        df = df.rename(columns={"SubscriberKey": "cpf"})
+        print("RENAME APLICADO: SubscriberKey → cpf") 
+
+    print(f"[DEBUG] Colunas antes da validação: {list(df.columns)}")
+
+    # Valida colunas obrigatórias para o log SF: cpf e telefone.
     # Lança ValueError imediatamente se alguma estiver ausente ou com dados inválidos.
-    validate_sf_dataframe(df, campaign_name) ## TODO: validar
+    validate_sf_dataframe(df, campaign_name)
 
     print(f"Query retornou {len(df)} linhas. Colunas: {list(df.columns)}")
+    print(f"[DEBUG] Sample data:\n{df.head(10).to_dict('records')}")
 
     # Dedup por CPF — base para o loop de retentativas
-    if filter_duplicated_cpfs and "SubscriberKey" in df.columns:
-        n_before = len(df)
-        df = df.drop_duplicates(subset=["SubscriberKey"])
-        print(f"Removed {n_before - len(df)} duplicate CPFs. Remaining: {len(df)}")
-
+    df = filter_duplicated(
+        df=df,
+        column="cpf",
+        filter_indicator=filter_duplicated_cpfs,
+        label="CPFs",
+    )
+    print(f"[DEBUG] Após filtrar cpfs duplicados:\n{df.head(10).to_dict('records')}") if debug else None
     if df.empty:
         print("No destinations found after filtering duplicate CPFs. Exiting flow execution.")
         return
 
-    # Remove telefones que falharam no último disparo
+    # Remove telefones cujo último disparo falhou e estão em quarentena
     if filter_failed_phones:
-        failed_phones = get_failed_phones(billing_project_id=billing_project_id)
+        print("Filtrando telefones em quarentena")
+        failed_phones = get_failed_phones(billing_project_id=billing_project_id)  # Considera falha em qq campanha
         if failed_phones:
             if max_dispatch_retries > 0:
                 # Marca como None para que o loop de retry use o próximo número de 'others'
                 df.loc[df["telefone"].isin(failed_phones), "telefone"] = None
             else:
                 df = df[~df["telefone"].isin(failed_phones)]
+            print(f"[DEBUG] Após filtrar quarentena:\n{df.head(10).to_dict('records')}") if debug else None
 
         if df.empty:
             send_dispatch_no_destinations_found(campaign_name, test_mode)
@@ -275,7 +292,6 @@ def rj_crm__disparo_template_sf(
             time.sleep(3 * 60)
             print(f"\n⚠️  Starting retry attempt {i} for campaign_name={campaign_name}...")
 
-            # TODO: get_failed_cpfs queries fluxo_atendimento (Wetalkie). Substituir por tabela SF quando disponível.
             failed_cpfs = get_failed_cpfs(billing_project_id=billing_project_id, campaign_name=campaign_name)
 
             if not failed_cpfs:
@@ -283,7 +299,7 @@ def rj_crm__disparo_template_sf(
                 break
 
             # Seleciona as linhas dos CPFs que falharam e aplica o próximo número de 'others'
-            retry_df = base_df[base_df["SubscriberKey"].isin(failed_cpfs)].copy()
+            retry_df = base_df[base_df["cpf"].isin(failed_cpfs)].copy()
             if "others" not in retry_df.columns or retry_df.empty:
                 print(f"No others column or no rows for retry attempt {i}.")
                 break
@@ -300,31 +316,74 @@ def rj_crm__disparo_template_sf(
             print(f"🚀 Found {len(current_df)} destinations for retry attempt {i}.")
 
         # Filtro de já disparados
-        # No retry por CPF, desliga o filtro de CPF (o mesmo CPF deve tentar outro número)
+        # No retry por CPF (i>0) eu não posso mais filtrar por cpfs já disparados
+        # e desligo o filtro para o mesmo CPF tentar outro número de telefone
         current_filter = filter_dispatched_phones_or_cpfs
         if i > 0 and current_filter == "cpf":
             current_filter = None
 
-        if current_filter:
-            # TODO: fluxo_atendimento é tabela Wetalkie. Substituir por tabela de controle SF quando disponível.
-            print(f"🔍 Checking if phones were already dispatched today...")
-            already_dispatched_df = get_already_dispatched_data(billing_project_id=billing_project_id)
-            already_dispatched_df = already_dispatched_df.rename(columns={"celular_disparo": "telefone"})
+        # Buscamos o histórico de disparos realizados no intervalo de dias configurado
+        already_dispatched_df = get_already_dispatched_data(
+            billing_project_id=billing_project_id, 
+            dispatch_interval_days=dispatch_interval_days
+        )
 
-            n_before = len(current_df)
-            if current_filter == "cpf" and "externalId" in already_dispatched_df.columns:
-                dispatched_set = set(already_dispatched_df["externalId"].dropna().tolist())
-                current_df = current_df[~current_df["externalId"].isin(dispatched_set)]
-            elif current_filter == "phone_number" and "telefone" in already_dispatched_df.columns:
-                dispatched_set = set(already_dispatched_df["telefone"].dropna().tolist())
-                current_df = current_df[~current_df["telefone"].isin(dispatched_set)]
-            print(f"Removed {n_before - len(current_df)} already dispatched. Remaining: {len(current_df)}")
+        # --------------------------------------------------------------------------------------
+        # PASSO 1: FILTRO DE SEGURANÇA DA MESMA CAMPANHA (ALWAYS CPF/SUBSCRIBERKEY)
+        # --------------------------------------------------------------------------------------
+        # Esse filtro impede que o mesmo CPF (SubscriberKey) receba a MESMA campanha mais de uma
+        # vez dentro da janela configurada (ex: 7 dias). Ele é um limite de segurança rígido
+        # e roda sempre usando "SubscriberKey" (CPF) como chave identificadora no current_df.
+        # --------------------------------------------------------------------------------------
+        qnt_pessoas = current_df.shape[0]
+        if not already_dispatched_df.empty:
+            print(f"🔍 Aplicando filtro de mesma campanha ({campaign_name}) sobre o CPF/SubscriberKey...")
+            df_same_campaign = already_dispatched_df[already_dispatched_df["nome_campanha"] == campaign_name]
+            print(f"[DEBUG] MEsma campanha data:\n{df_same_campaign.head(10).to_dict('records')}") if debug else None
+
+            current_df = filter_already_dispatched_phones_or_cpfs(
+                df=current_df,
+                already_dispatched_df=df_same_campaign,
+                current_filter="cpf",
+            )
+            print(f"🔍 Foram removidas {qnt_pessoas - current_df.shape[0]} pessoas da lista de envio que já receberam essa campanha nos último(s) {dispatch_interval_days} dia(s).")
+            print(f"[DEBUG] Após remoção de mesma campanha:\n{current_df.head(10).to_dict('records')}") if debug else None
+
+        # --------------------------------------------------------------------------------------
+        # PASSO 2: FILTRO DIÁRIO CRUZADO DE CANAL (CPF ou Telefone)
+        # --------------------------------------------------------------------------------------
+        # Esse filtro impede que o mesmo cidadão receba QUALQUER outra campanha no dia de hoje
+        # para evitar fadiga ou duplicidade de comunicação no mesmo canal.
+        # - Só roda se 'current_filter' não for None (ou seja, se o usuário ativou o filtro diário
+        #   e não estamos em uma retentativa de CPF i > 0).
+        # - Respeita a coluna ativa ('SubscriberKey' ou 'telefone') para a comparação.
+        # --------------------------------------------------------------------------------------
+        if current_filter and not already_dispatched_df.empty:
+            # Se o filtro ativo no envio for "cpf", nós mapeamos para "SubscriberKey" para comparar
+            # com a coluna de controle (que no get_already_dispatched_data retorna como "cpf").
+            print(f"🔍 Aplicando filtro diário de quem já recebeu alguma campanha hoje '{current_filter}'...")
+            
+            hoje = pd.Timestamp.now(tz='America/Sao_Paulo').date()
+            datas_disparadas = pd.to_datetime(already_dispatched_df["data_particao"]).dt.date
+            qnt_pessoas = current_df.shape[0]
+            # Selecionamos apenas as linhas de disparos que ocorreram no dia de hoje
+            df_dispatched_today = already_dispatched_df[datas_disparadas == hoje]
+            
+            current_df = filter_already_dispatched_phones_or_cpfs(
+                df=current_df,
+                already_dispatched_df=df_dispatched_today,
+                current_filter=current_filter,
+            )
+            print(f"🔍 Foram removidas {qnt_pessoas - current_df.shape[0]} pessoas da lista de envio que já receberam alguma campanha hoje.")
+            print(f"[DEBUG] Já tiveram disparo hoje:\n{df_dispatched_today.to_dict('records')}") if debug else None
 
         # Dedup por telefone (retries podem introduzir duplicatas)
-        if filter_duplicated_phones and "telefone" in current_df.columns:
-            n_before = len(current_df)
-            current_df = current_df.drop_duplicates(subset=["telefone"])
-            print(f"Removed {n_before - len(current_df)} duplicate phones.")
+        current_df = filter_duplicated(
+            df=current_df,
+            column="telefone",
+            filter_indicator=filter_duplicated_phones,
+            label="phones",
+        )
 
         if current_df.empty:
             print("No destinations found. Exiting flow execution.")
@@ -335,7 +394,7 @@ def rj_crm__disparo_template_sf(
         # Whitelist (funções esperam List[Dict] com chave 'to')
         if whitelist_percentage > 0:
             whitelist_group_name = f"citizen-hsm-{campaign_name}"
-            whitelist_dests = [{"to": phone} for phone in current_df["telefone"].tolist()]
+            whitelist_dests = [{"telefone": phone} for phone in current_df["telefone"].tolist()]
             if whitelist_replace_contacts:
                 remove_contacts_from_whitelist(destinations=whitelist_dests, environment=whitelist_environment)
             add_contacts_to_whitelist(
@@ -347,13 +406,13 @@ def rj_crm__disparo_template_sf(
             )
 
         print(f"\nStarting SF dispatch for campaign_name={campaign_name}, attempt={i}")
-        print(f"Sample data:\n{current_df.head(2).to_dict('records')}")
+        print(f"Sample data:\n{current_df.head(5).to_dict('records')}")
         print(f"⚠️  Sleep {sleep_minutes} minutes before dispatch. Check if event date and campaign_name is correct!!")
         time.sleep(sleep_minutes * 60)
 
         # Salva CSV (restrito a telefone/SubscriberKey/de_columns) e registra data do disparo
         csv_path, dispatch_date = save_csv_for_sftp(
-            df=current_df,
+            df=current_df.rename(columns={"cpf": "SubscriberKey"}),
             data_extension_filename=data_extension_filename or campaign_name,
             de_columns=de_columns,
             csv_separator=csv_separator,
@@ -407,7 +466,7 @@ def rj_crm__disparo_template_sf(
                 print(f"Sample dispatched destination: {current_df.iloc[:5].to_dict()}")
                 # Log para BQ: schema fixo com coluna `data` em JSON para camada bronze
                 log_df = create_log_df(
-                    df=current_df,
+                    df=current_df.rename(columns={"cpf": "SubscriberKey"}),
                     dispatch_date=dispatch_date,
                     campaign_name=campaign_name,
                 )

--- a/pipelines/rj_crm__disparo_template/flow.py
+++ b/pipelines/rj_crm__disparo_template/flow.py
@@ -289,8 +289,17 @@ def rj_crm__disparo_template_sf(
 
         if i == 0:
             current_df = base_df.copy()
-            # No primeiro disparo, exclui linhas com telefone None (marcadas por filter_failed_phones)
+            # Para linhas com telefone None (marcadas por filter_failed_phones),
+            # tenta usar o primeiro número disponível em 'others' antes de descartar
+            if "others" in current_df.columns:
+                mask_none = current_df["telefone"].isna()
+                current_df.loc[mask_none, "telefone"] = current_df.loc[mask_none, "others"].apply(
+                    lambda x: x[0] if isinstance(x, list) and len(x) >= 1 else None
+                )
             current_df = current_df.dropna(subset=["telefone"])
+            if current_df.shape[0] == 0:
+                print("✅ No destinations available for dispatch attempt 0. Ending.")
+                break
         else:
             if "others" in base_df.columns and not base_df["others"].apply(
                 lambda x: isinstance(x, list) and len(x) >= i
@@ -396,7 +405,7 @@ def rj_crm__disparo_template_sf(
             )
             
             print(f"🔍 Foram removidas {qnt_pessoas - current_df.shape[0]} pessoas da lista de envio que já receberam alguma campanha hoje.")
-            print(f"[DEBUG] Já tiveram disparo hoje:\n{df_dispatched_today.to_dict('records')}") if debug else None
+            print(f"[DEBUG] Já tiveram disparo hoje:\n{df_dispatched_today.head().to_dict('records')}") if debug else None
 
         # Dedup por telefone (retries podem introduzir duplicatas)
         current_df = filter_duplicated(

--- a/pipelines/rj_crm__disparo_template/prefect.yaml
+++ b/pipelines/rj_crm__disparo_template/prefect.yaml
@@ -1134,6 +1134,7 @@ deployments:
             nome_hsm_placeholder: smspuerperasdisparo152
             nome_hsm_anterior_placeholder: smspuerperasdisparo25
             id_hsm_anterior_legado_placeholder: 610
+            id_hsm_legado_placeholder": 598
             pesquisa_id: "Pesquisa 7"
             datas_internacao: "DATE_ADD(DATE(data_alta_internacao), INTERVAL 40 DAY)"
             intervalo_filtro_disparados: 1

--- a/pipelines/rj_crm__disparo_template/scheduler_sf.yaml
+++ b/pipelines/rj_crm__disparo_template/scheduler_sf.yaml
@@ -383,6 +383,7 @@ schedules:
             nome_hsm_placeholder: smspuerperasdisparo152
             nome_hsm_anterior_placeholder: smspuerperasdisparo25
             id_hsm_anterior_legado_placeholder: 610
+            id_hsm_legado_placeholder: 589
             pesquisa_id: "Pesquisa 7"
             datas_internacao: "DATE_ADD(DATE(data_alta_internacao), INTERVAL 40 DAY)"
             intervalo_filtro_disparados: 1

--- a/pipelines/rj_crm__disparo_template/utils/discord.py
+++ b/pipelines/rj_crm__disparo_template/utils/discord.py
@@ -331,11 +331,24 @@ def _format_sample_destination(destination: dict) -> str:
         String formatada em JSON
     """
 
-    # Create a clean sample with only relevant fields
+    # Mascarar CPF exibindo apenas os 3 primeiros dígitos
+    raw_cpf = destination.get("cpf", "") or ""
+    masked_cpf = raw_cpf[:3] + "*" * max(0, len(str(raw_cpf)) - 3)
+
+    # Campos excluídos do sample (exibidos com tratamento especial ou omitidos)
+    excluded_fields = {"telefone", "cpf"}
+
+    # Todos os demais campos do destination, sem telefone e cpf
+    extra_fields = {
+        k: v for k, v in destination.items()
+        if k not in excluded_fields
+    }
+
+    # Create a clean sample: telefone, cpf mascarado e demais campos na raiz
     sample = {
         "telefone": destination.get("telefone", ""),
-        "cpf": destination.get("cpf", ""),
-        "vars": destination.get("vars", {}),
+        "cpf": masked_cpf,
+        **extra_fields,
     }
 
     return json.dumps(sample, indent=2, ensure_ascii=False)

--- a/pipelines/rj_crm__disparo_template/utils/discord.py
+++ b/pipelines/rj_crm__disparo_template/utils/discord.py
@@ -333,8 +333,8 @@ def _format_sample_destination(destination: dict) -> str:
 
     # Create a clean sample with only relevant fields
     sample = {
-        "to": destination.get("to", ""),
-        "externalId": destination.get("externalId", ""),
+        "telefone": destination.get("telefone", ""),
+        "cpf": destination.get("cpf", ""),
         "vars": destination.get("vars", {}),
     }
 

--- a/pipelines/rj_crm__disparo_template/utils/discord.py
+++ b/pipelines/rj_crm__disparo_template/utils/discord.py
@@ -351,6 +351,8 @@ def _format_sample_destination(destination: dict) -> str:
         **extra_fields,
     }
 
+    sample = {k: str(v) for k, v in sample.items()}
+
     return json.dumps(sample, indent=2, ensure_ascii=False)
 
 

--- a/pipelines/rj_crm__disparo_template/utils/dispatch.py
+++ b/pipelines/rj_crm__disparo_template/utils/dispatch.py
@@ -487,6 +487,8 @@ def get_already_dispatched_data(billing_project_id: str, dispatch_interval_days:
             envio_datahora >= DATE_SUB(CURRENT_DATE("America/Sao_Paulo"), INTERVAL {dispatch_interval_days} DAY)
               OR
             entrega_datahora >= DATE_SUB(CURRENT_DATE("America/Sao_Paulo"), INTERVAL {dispatch_interval_days} DAY)
+              OR
+            falha_datahora >= DATE_SUB(CURRENT_DATE("America/Sao_Paulo"), INTERVAL {dispatch_interval_days} DAY)
             )
     """
     log(f"Buscando disparos já realizados hoje e na campanha para evitar duplicidade:\n{query}")

--- a/pipelines/rj_crm__disparo_template/utils/dispatch.py
+++ b/pipelines/rj_crm__disparo_template/utils/dispatch.py
@@ -619,7 +619,7 @@ def get_destinations(
 
     if destinations:
         print(f"Exemplo de destino antes da normalização: {destinations[0]}")
-        # Normaliza as chaves (ex: EXTERNALID -> externalId, celular_disparo -> to)
+        # Normaliza as chaves (ex: EXTERNALID -> cpf, celular_disparo -> telefone)
         destinations = [normalize_keys(d) for d in destinations]
         print(f"Exemplo de destino após a normalização: {destinations[0]}")
 
@@ -861,11 +861,15 @@ def check_flow_status(
     current_date = datetime.now(timezone("America/Sao_Paulo")).date()
 
     raw_expiration = row.get("data_limite_disparo")
-    # NULL/NaT means no expiration — the flow runs indefinitely
+    # NULL/NaT means no expiration — the flow runs indefinitely.
+    # Normalise to datetime.date so the comparison with current_date is always type-safe.
+    expiration_date = None
     try:
-        expiration_date = None if raw_expiration is None or pd.isnull(raw_expiration) else raw_expiration
+        if raw_expiration is not None and not pd.isnull(raw_expiration):
+            expiration_date = datetime.strptime(str(raw_expiration)[:10], "%Y-%m-%d").date()
     except (TypeError, ValueError):
-        expiration_date = raw_expiration
+        log(f"WARNING: data_limite_disparo value {raw_expiration!r} could not be parsed as a date. Treating as no expiration.")
+        expiration_date = None
 
     if expiration_date is not None and expiration_date < current_date:
         log(f"\n⚠️  Flow for campaign_name={campaign_name} in environment={flow_environment} has expired on {expiration_date}.")
@@ -1011,7 +1015,6 @@ def get_failed_cpfs(billing_project_id: str, campaign_name: str,) -> set:
     return failed_cpfs
     
 
-@task
 def check_campaign_success(
     billing_project_id: str,
     campaign_name: str,

--- a/pipelines/rj_crm__disparo_template/utils/dispatch.py
+++ b/pipelines/rj_crm__disparo_template/utils/dispatch.py
@@ -1036,18 +1036,15 @@ def check_campaign_success(
         SELECT COUNT(*) AS total_sucesso
         FROM `rj-crm-registry.brutos_salesforce.status_disparo`
         WHERE LOWER(nome_hsm) = LOWER('{campaign_name}')
-          AND envio_datahora >= '{dispatch_date}'
+          AND (envio_datahora >= '{dispatch_date}' or falha_datahora >= '{dispatch_date}')
           AND data_particao >= DATE('{dispatch_date}')
-          AND indicador_falha = FALSE
-          AND indicador_quarentena = FALSE
-          AND entrega_datahora IS NOT NULL
     """
     try:
         df = download_data_from_bigquery(
             query=query, billing_project_id=billing_project_id, bucket_name=billing_project_id
         )
         total = int(df.iloc[0]["total_sucesso"]) if not df.empty else 0
-        log(f"check_campaign_success: {total} disparo(s) com sucesso confirmado para '{campaign_name}' desde {dispatch_date}.")
+        log(f"check_campaign_success: {total} disparo(s) com recebimento de webhook confirmado para '{campaign_name}' desde {dispatch_date}.")
         return total > 0
     except Exception as e:
         log(f"Erro ao verificar sucesso do disparo: {e}", level="warning")

--- a/pipelines/rj_crm__disparo_template/utils/dispatch.py
+++ b/pipelines/rj_crm__disparo_template/utils/dispatch.py
@@ -66,7 +66,7 @@ def add_contacts_to_whitelist(
     phone_numbers = []
     for dest_json in destinations:
         try:
-            phone = dest_json.get("to")
+            phone = dest_json.get("telefone")
             if phone:
                 phone_numbers.append(phone)
         except Exception as err:
@@ -174,7 +174,7 @@ def remove_contacts_from_whitelist(
     phone_numbers = []
     for dest in destinations:
         try:
-            phone = dest.get("to")
+            phone = dest.get("telefone")
             print(f"DEBUG: Processing destinations for removal, found phone: {phone} in destination: {dest}")
             if phone:
                 phone_numbers.append(phone)
@@ -243,10 +243,10 @@ def create_dispatch_payload(campaign_name: str, cost_center_id: int, destination
     if isinstance(destinations, pd.DataFrame):
         destinations = destinations.to_dict("records")
     
-    # TODO: quando filtramos os telefones com failed e temos retentativa, o dado chega aqui com 
-    # to: None e others: [prox_num1, prox_num2...], mas o schema exige que to seja string.
+    # TODO: quando filtramos os telefones com failed e temos retentativa, o dado chega aqui com
+    # telefone: None e others: [prox_num1, prox_num2...], mas o schema exige que telefone seja string.
     # Poderia aqui remover esses casos do payload
-    # Exemplo do dado aqui: [{'to': None, 'externalId': '00000000011', 'vars': {'NOME': 'Rodolpho ', 'CC_WT_NOME': 'Rodolpho ', 'CC_WT_CPF_CIDADAO': '00000000011'}, 'others': ['5511984677798']}, {'to': None, 'externalId': '00000000011', 'vars': {'NOME': 'Patricia ', 'CC_WT_NOME': 'Patricia ', 'CC_WT_CPF_CIDADAO': '00000000011'}, 'others': ['5511984677798']}, {'to': '5592984212629', 'externalId': '00000000055', 'vars': {'NOME': 'Patrick ', 'CC_WT_NOME': 'Patrick ', 'CC_WT_CPF_CIDADAO': '00000000055'}, 'others': ['5592984212629']}]
+    # Exemplo do dado aqui: [{'telefone': None, 'cpf': '00000000011', 'vars': {...}, 'others': ['5511984677798']}, ...]
     # como não tem failed ele não entra no retry loop
 
     # Validate destinations first
@@ -262,7 +262,7 @@ def create_dispatch_payload(campaign_name: str, cost_center_id: int, destination
 
     # Retorna o dicionário EXCLUINDO o campo 'others' de todos os destinatários na lista
     # Isso garante que a API não receba um campo que ela não conhece
-    return payload.dict(exclude={"destinations": {"__all__": {"others"}}})
+    return payload.model_dump(exclude={"destinations": {"__all__": {"others"}}})
 
 
 @task
@@ -333,8 +333,8 @@ def create_dispatch_dfr(
             "dispatch_date": dispatch_date,
             "campaignName": campaign_name,
             "costCenterId": cost_center_id,
-            "to": destination.to,
-            "externalId": destination.externalId,  # Now mandatory
+            "telefone": destination.telefone,
+            "cpf": destination.cpf,
             "vars": destination.vars,
         }
         data.append(row)
@@ -346,19 +346,19 @@ def create_dispatch_dfr(
             "dispatch_date",
             "campaignName",
             "costCenterId",
-            "to",
-            "externalId",
+            "telefone",
+            "cpf",
             "vars",
         ]
     ]
 
     log(f"DataFrame created with {len(dfr)} validated records")
-    log("All records have mandatory externalId field populated")
+    log("All records have mandatory cpf field populated")
 
-    # Validate that no externalId is None (should not happen with our validation)
-    null_external_ids = dfr["externalId"].isnull().sum()
-    if null_external_ids > 0:
-        log(f"WARNING: Found {null_external_ids} records with null externalId after validation")
+    # Validate that no cpf is None (should not happen with our validation)
+    null_cpfs = dfr["cpf"].isnull().sum()
+    if null_cpfs > 0:
+        log(f"WARNING: Found {null_cpfs} records with null cpf after validation")
 
     return dfr
 
@@ -410,7 +410,7 @@ def create_log_df(
             validated = SfDispatchRow(
                 dispatch_date=str(dispatch_date),
                 campaign_name=str(campaign_name),
-                SubscriberKey=str(row.get("SubscriberKey", "")),
+                cpf=str(row.get("SubscriberKey", "")),
                 telefone=str(row.get("telefone", "")),
             )
         except Exception as e:  # pylint: disable=broad-except
@@ -435,7 +435,7 @@ def create_log_df(
         records.append({
             "dispatch_date": validated.dispatch_date,
             "campaign_name": validated.campaign_name,
-            "SubscriberKey": validated.SubscriberKey,
+            "SubscriberKey": validated.cpf,
             "telefone": validated.telefone,
             "data": json.dumps(extra_data, ensure_ascii=False, default=str),
         })
@@ -471,18 +471,20 @@ def check_api_status(api: object) -> bool:
 
 
 @task
-def get_already_dispatched_data(billing_project_id: str) -> pd.DataFrame:
+def get_already_dispatched_data(billing_project_id: str, dispatch_interval_days: int) -> pd.DataFrame:
     """
     Busca no BigQuery a lista de CPFs ou telefones que já tiveram um disparo
-    bem-sucedido ou em processamento hoje.
+    bem-sucedido ou em processamento hoje. Filtramos pela data de envio ou entrega
+    porque a coluna status_disparo guarda apenas o status final, e se uma pessoa leu a mensagem
+    uma semana depois ela deveria poder receber outro disparo hoje.
     """
-    query = """
-        SELECT DISTINCT targetExternalId as externalId, flatTarget as celular_disparo, status
-        FROM `rj-crm-registry.brutos_wetalkie_staging.fluxo_atendimento_*`
-        WHERE DATE(createDate) = CURRENT_DATE("America/Sao_Paulo")
-          AND status IN ("PROCESSING", "SENT", "DELIVERED", "READ")
+    query = f"""
+        SELECT DISTINCT cpf , contato_telefone as telefone, status_disparo as status, nome_hsm as nome_campanha, data_particao
+        FROM `rj-crm-registry.brutos_salesforce.status_disparo`
+        WHERE data_particao >= DATE_SUB(CURRENT_DATE("America/Sao_Paulo"), INTERVAL {dispatch_interval_days} DAY)
+          AND (envio_datahora is not null OR entrega_datahora is not null)
     """
-    log(f"Buscando disparos já realizados hoje para evitar duplicidade:\n{query}")
+    log(f"Buscando disparos já realizados hoje e na campanha para evitar duplicidade:\n{query}")
     try:
         df = download_data_from_bigquery(
             query=query, billing_project_id=billing_project_id, bucket_name=billing_project_id
@@ -490,53 +492,69 @@ def get_already_dispatched_data(billing_project_id: str) -> pd.DataFrame:
         return df
     except Exception as err:
         log(f"Erro ao buscar disparos realizados: {err}. Retornando DataFrame vazio.", level="warning")
-        return pd.DataFrame(columns=["externalId", "celular_disparo", "status"])
+        return pd.DataFrame(columns=["cpf", "telefone", "status", "nome_campanha", "data_particao"])
+
+
+@task
+def filter_duplicated(
+    df: pd.DataFrame,
+    column: str,
+    filter_indicator: bool,
+    label: str,
+) -> pd.DataFrame:
+    """
+    Remove duplicate entries from a DataFrame based on a specified column.
+    Only executes if filter_indicator is True.
+    """
+    if df is None or df.empty:
+        return df
+
+    if filter_indicator and column in df.columns:
+        n_before = len(df)
+        df = df.drop_duplicates(subset=[column])
+        log(f"Removed {n_before - len(df)} duplicated {label}. Remaining: {len(df)}")
+    return df
 
 
 @task
 def filter_already_dispatched_phones_or_cpfs(
-    destinations: List[Dict], 
-    already_dispatched_df: pd.DataFrame, 
-    field: str = "cpf"
-) -> List[Dict]:
+    df: pd.DataFrame,
+    already_dispatched_df: pd.DataFrame,
+    current_filter: str = 'cpf'
+) -> pd.DataFrame:
     """
-    Filters out CPFs that have already been dispatched today.
-
-    Args:
-        destinations (List[Dict]): A list of destination dictionaries.
-        already_dispatched_df (pd.DataFrame): A DataFrame containing already dispatched destinations.
-        field (str): The field in the destination dict that contains the phone number.
-            Field must be "cpf" or "phone_number"
-
-    Returns:
-        List[Dict]: A list of destination dictionaries that have not yet been dispatched.
+    Filters out rows from the DataFrame where the identifier (cpf or phone) 
+    has already been dispatched today.
     """
-    if not destinations or already_dispatched_df.empty:
-        return destinations
+    if df is None or df.empty or already_dispatched_df.empty:
+        return df
 
-    if field not in ["cpf", "phone_number"]:
-        log(f"\n⚠️  Invalid field '{field}' for filtering dispatched phones. Must be 'cpf' or 'phone_number'")
-        return destinations
-
-    already_dispatched_df.rename(columns={"celular_disparo": "to"}, inplace=True)
-
-    destinations_field = "externalId" if field == "cpf" else "to"
-    already_dispatched_field = "externalId" if field == "cpf" else "to"
-
-    if already_dispatched_field not in already_dispatched_df.columns:
-        log(f"Coluna {already_dispatched_field} não encontrada nos dados de controle. Ignorando filtro.", level="warning")
-        return destinations
-
-    dispatched_set = set(already_dispatched_df[already_dispatched_field].tolist())
+    # Mapeamos o filtro informado para as colunas corretas de cada DataFrame: (col_envio, col_controle)
+    # - col_envio: nome da coluna no DataFrame de envio (df), que para CPF é 'cpf'.
+    # - col_controle: nome da coluna no DataFrame de controle (already_dispatched_df), que para CPF também é 'cpf'.
+    mapping = {
+        "cpf": ("cpf", "cpf"),
+        "SubscriberKey": ("cpf", "cpf"),
+        "telefone": ("telefone", "telefone"),
+        None: ("cpf", "cpf")
+    }
     
-    filtered_destinations = [
-        dest for dest in destinations if dest.get(destinations_field) not in dispatched_set
-    ]
+    col_envio, col_controle = mapping.get(current_filter, ("cpf", "cpf"))
+
+    if col_envio not in df.columns:
+        log(f"Coluna {col_envio} não encontrada no DataFrame de envio. Ignorando filtro.", level="warning")
+        return df
+
+    if col_controle not in already_dispatched_df.columns:
+        log(f"Coluna {col_controle} não encontrada no controle de já disparados. Ignorando filtro.", level="warning")
+        return df
+
+    n_before = len(df)
+    dispatched_set = set(already_dispatched_df[col_controle].dropna())
+    df = df[~df[col_envio].isin(dispatched_set)]
+    log(f"Removed {n_before - len(df)} already dispatched {col_envio}. Remaining: {len(df)}")
     
-    removed_count = len(destinations) - len(filtered_destinations)
-    log(f"Filtro '{field}' aplicado: {removed_count} registros removidos por já terem disparos realizados hoje.")
-    
-    return filtered_destinations
+    return df
 
 
 def normalize_keys(d: Dict) -> Dict:
@@ -545,10 +563,13 @@ def normalize_keys(d: Dict) -> Dict:
             return d
         
         mapping = {
-            "celular_disparo": "to",
-            "to": "to",
-            "externalid": "externalId",
-            "external_id": "externalId",
+            "celular_disparo": "telefone",
+            "to": "telefone",
+            "telefone": "telefone",
+            "externalid": "cpf",
+            "external_id": "cpf",
+            "externalId": "cpf",
+            "cpf": "cpf",
             "vars": "vars",
             "others": "others"
         }
@@ -604,7 +625,7 @@ def get_destinations(
 
         validated_destinations, validation_stats = validate_destinations(destinations)
         log_validation_summary(validation_stats, "get_destinations")
-        return [dest.dict() for dest in validated_destinations]
+        return [dest.model_dump() for dest in validated_destinations]
 
     return []
 
@@ -630,15 +651,15 @@ def remove_duplicate_phones(destinations: List[Dict]) -> List[Dict]:
     duplicates_count = 0
 
     for destination in validated_destinations:
-        phone = destination.to  # Pydantic model attribute
-        external_id = destination.externalId
+        phone = destination.telefone  # Pydantic model attribute
+        cpf = destination.cpf
 
         if phone not in seen_phones:
             seen_phones.add(phone)
-            unique_destinations.append(destination.dict())  # Convert back to dict
+            unique_destinations.append(destination.model_dump())  # Convert back to dict
         else:
             duplicates_count += 1
-            log(f"Duplicate phone removed: {phone[:8]}**** (externalId: {external_id})")
+            log(f"Duplicate phone removed: {phone[:8]}**** (cpf: {cpf})")
 
     log(f"Removed {duplicates_count} duplicate phone numbers")
     log(f"Total unique destinations: {len(unique_destinations)}")
@@ -667,14 +688,14 @@ def remove_duplicate_cpfs(destinations: List[Dict]) -> List[Dict]:
     duplicates_count = 0
 
     for destination in validated_destinations:
-        cpf = destination.externalId  # Pydantic model attribute
+        cpf = destination.cpf  # Pydantic model attribute
 
         if cpf not in seen_cpfs:
             seen_cpfs.add(cpf)
-            unique_destinations.append(destination.dict())  # Convert back to dict
+            unique_destinations.append(destination.model_dump())  # Convert back to dict
         else:
             duplicates_count += 1
-            log(f"Duplicate CPF removed: {cpf[:4]}**** (phone: {destination.to})")
+            log(f"Duplicate CPF removed: {cpf[:4]}**** (phone: {destination.telefone})")
 
     log(f"Removed {duplicates_count} duplicate CPFs")
     log(f"Total unique destinations: {len(unique_destinations)}")
@@ -823,7 +844,9 @@ def check_flow_status(
     if not webhook_url:
         print("DISCORD_WEBHOOK_URL_ERRORS environment variable not set. Cannot send notification.")
 
-    if not row.get("ativo") or row.get("ativo") not in (1, "1"):
+    ativo_raw = row.get("ativo")
+    is_ativo = str(ativo_raw).strip().lower() in ("1", "true", "yes", "sim", "ativo") if ativo_raw is not None else False
+    if not is_ativo:
         log(f"\n⚠️  Flow is not active for {row.get('nome_campanha')} in environment={flow_environment}.")
         message = f"""
     Prefect flow run desativado em https://docs.google.com/spreadsheets/d/1O-noD696ZjIr9X_Vl4ZKyFDyg0q9KHe9jacExdAp4ck/!
@@ -837,9 +860,14 @@ def check_flow_status(
 
     current_date = datetime.now(timezone("America/Sao_Paulo")).date()
 
-    expiration_date = row.get("data_limite_disparo") if not pd.isnull(row.get("data_limite_disparo")) else current_date
+    raw_expiration = row.get("data_limite_disparo")
+    # NULL/NaT means no expiration — the flow runs indefinitely
+    try:
+        expiration_date = None if raw_expiration is None or pd.isnull(raw_expiration) else raw_expiration
+    except (TypeError, ValueError):
+        expiration_date = raw_expiration
 
-    if expiration_date < current_date:
+    if expiration_date is not None and expiration_date < current_date:
         log(f"\n⚠️  Flow for campaign_name={campaign_name} in environment={flow_environment} has expired on {expiration_date}.")
         message = f"""
     Prefect flow run atingiu a data limite em https://docs.google.com/spreadsheets/d/1O-noD696ZjIr9X_Vl4ZKyFDyg0q9KHe9jacExdAp4ck/!
@@ -938,7 +966,8 @@ def get_failed_phones(billing_project_id: str, campaign_name: str = None) -> set
             billing_project_id=billing_project_id,
             bucket_name=billing_project_id
         )
-        print(f"DEBUG: Primeiro ID com falha detectado: {failed_df.iloc[0]}... (total {failed_df.shape[0]})")
+        if not failed_df.empty:
+            print(f"DEBUG: Primeiro ID com falha detectado: {failed_df.iloc[0]}... (total {failed_df.shape[0]})")
         failed_phones = set(str(x) for x in failed_df['telefone'].tolist())
         return failed_phones
     except Exception as e:
@@ -951,6 +980,7 @@ def get_failed_cpfs(billing_project_id: str, campaign_name: str,) -> set:
     """
     Busca CPFs tiveram falha de não ter whatsapp ou bloqueio no disparo das últimas 2 horas,
     """
+    campaign_filter = f"AND LOWER(nome_hsm) = LOWER('{campaign_name}')" if campaign_name else ""
     query = f"""
         -- Agora só teremos Salesforce como fonte
         SELECT DISTINCT cpf
@@ -958,7 +988,7 @@ def get_failed_cpfs(billing_project_id: str, campaign_name: str,) -> set:
         WHERE indicador_quarentena = TRUE
         AND envio_datahora >= datetime_sub(current_datetime("America/Sao_Paulo"), INTERVAL 4 hour)
         AND data_particao >= date_sub(current_date("America/Sao_Paulo"), INTERVAL 1 day)
-        AND LOWER(nome_hsm) = LOWER('{campaign_name}') if campaign_name else ''
+        {campaign_filter}
     """
     try:
         failed_df = download_data_from_bigquery(
@@ -966,7 +996,8 @@ def get_failed_cpfs(billing_project_id: str, campaign_name: str,) -> set:
             billing_project_id=billing_project_id,
             bucket_name=billing_project_id
         )
-        print(f"DEBUG: Primeiro ID com falha detectado para retentativa: {failed_df.iloc[0]}... (total {failed_df.shape[0]})")
+        if not failed_df.empty:
+            print(f"DEBUG: Primeiro ID com falha detectado para retentativa: {failed_df.iloc[0]}... (total {failed_df.shape[0]})")
         failed_cpfs = set(str(x) for x in failed_df['cpf'].tolist())
         print(f"DEBUG failed_cpfs {failed_cpfs}")
     except Exception as e:
@@ -1091,17 +1122,17 @@ def remove_failed_phones(
     print(f"We have on DL {len(failed_phones)} destinations with previously failed phones.")
     new_destinations = []
     for dest in original_destinations:
-        # Busca to ignorando o "case"
-        to_number = get_value_from_case_insensitive_key(dest, 'to')
+        # Busca telefone ignorando o "case"
+        to_number = get_value_from_case_insensitive_key(dest, 'telefone')
 
         # if to_number is not None and str(to_number) not in failed_phones and max_dispatch_retries==0:
         #     new_destinations.append(dest)
         if (to_number is None or str(to_number) in failed_phones) and max_dispatch_retries==0:
             pass  # Se o telefone principal falhou e não há retentativas, removemos o destino completamente
         elif str(to_number) in failed_phones and max_dispatch_retries>0:
-            # Atualiza o campo 'to' com None para os telefones que falharam, forçando a retentativa a usar o próximo número da lista 'others'
+            # Atualiza o campo 'telefone' com None para os telefones que falharam, forçando a retentativa a usar o próximo número da lista 'others'
             new_dest = dest.copy()
-            new_dest['to'] = None
+            new_dest['telefone'] = None
             print(f"DEBUG: {to_number} falhou no último disparo e foi alterado para None = {new_dest}")
             new_destinations.append(new_dest)
         else:
@@ -1124,8 +1155,8 @@ def get_retry_destinations(
 
     Exemplo de como deve estar o schema da query:
     {
-       "celular_disparo": "5521999999999",
-       "externalId": "12345678901",
+       "telefone": "5521999999999",
+       "cpf": "12345678901",
        "vars": {
          "nome_usuario": "João Silva"
        },
@@ -1147,10 +1178,10 @@ def get_retry_destinations(
 
     retry_destinations = []
     for dest in original_destinations:
-        # Busca externalId e others ignorando o "case"
-        ext_id = get_value_from_case_insensitive_key(dest, 'externalId')
+        # Busca cpf e others ignorando o "case"
+        ext_id = get_value_from_case_insensitive_key(dest, 'cpf')
         others = get_value_from_case_insensitive_key(dest, 'others') or []
-        to_number = get_value_from_case_insensitive_key(dest, 'to')
+        to_number = get_value_from_case_insensitive_key(dest, 'telefone')
         log(f"DEBUG dest {dest}")
 
         # Condições de elegibilidade para retry: telefone faltando/inválido + retry attempt válido
@@ -1161,8 +1192,8 @@ def get_retry_destinations(
 
         if (is_ext_missing or is_failed_id or is_to_number_missing) and can_retry:
             new_dest = dest.copy()
-            # Atualiza o campo 'to' com o número da repescagem (tentativa 1 pega others[0])
-            new_dest['to'] = others[attempt_number - 1]
+            # Atualiza o campo 'telefone' com o número da repescagem (tentativa 1 pega others[0])
+            new_dest['telefone'] = others[attempt_number - 1]
             log(f"DEBUG: new_dest alterado = {new_dest}")
             retry_destinations.append(new_dest)
         elif attempt_number == 0:
@@ -1185,7 +1216,7 @@ def save_csv_for_sftp(
 
     Se `de_columns` for informado, o CSV é restrito a 'telefone' + 'SubscriberKey' +
     `de_columns` (os campos que a Data Extension espera) — qualquer coluna de controle
-    interno do flow (ex.: 'others', 'externalId') é descartada, mesmo que a query as
+    interno do flow (ex.: 'others', 'cpf') é descartada, mesmo que a query as
     retorne. Sem `de_columns`, mantém o comportamento legado de só descartar 'others'.
 
     `csv_separator` define o delimitador do CSV (padrão ';'); algumas Data Extensions
@@ -1297,17 +1328,17 @@ def send_to_sftp(
         log("Conexão estabelecida com sucesso ao SFTP!")
         
         # Listagem do diretório inicial para debug
-        try:
-            log(f"Diretório atual (pwd): {sftp.getcwd()}")
-            log(f"Diretório de destino: {sftp_remote_path}")
-            log(f"Conteúdo do diretório inicial: {sftp.listdir('.')}")
-        except Exception as e:
-            log(f"Não foi possível listar o diretório inicial: {e}")
+        # try:
+        #     log(f"Diretório atual (pwd): {sftp.getcwd()}")
+        #     log(f"Diretório de destino: {sftp_remote_path}")
+        #     log(f"Conteúdo do diretório inicial: {sftp.listdir('.')}")
+        # except Exception as e:
+        #     log(f"Não foi possível listar o diretório inicial: {e}")
         
         if sftp_remote_path and sftp_remote_path != '/':
             try:
                 sftp.chdir(sftp_remote_path)
-                log(f"Alterado para o diretório: {sftp_remote_path}")
+                # log(f"Alterado para o diretório: {sftp_remote_path}")
             except IOError:
                 log(f"Diretório {sftp_remote_path} não encontrado. Tentando criar...")
 
@@ -1324,6 +1355,7 @@ def send_to_sftp(
         
     except Exception as e:
         log(f"Erro: {str(e)}")
+        raise
     finally:
         if ssh:
             ssh.close()

--- a/pipelines/rj_crm__disparo_template/utils/processors.py
+++ b/pipelines/rj_crm__disparo_template/utils/processors.py
@@ -14,7 +14,7 @@ from iplanrio.pipelines_utils.logging import log  # pylint: disable=E0611, E0401
 from pipelines.rj_crm__disparo_template.constants import TemplateConstants  # pylint: disable=E0611, E0401
 
 
-def process_skip_weekends_on_query(query: str = None, replacements: dict = {}) -> str:
+def process_skip_weekends_on_query(query: str = None, replacements: dict = None) -> str:
     """
     Processes query by substituting dynamic values.
     If no query provided, uses the one from constants.
@@ -29,6 +29,9 @@ def process_skip_weekends_on_query(query: str = None, replacements: dict = {}) -
     Raises:
         ValueError: If {days_ahead_placeholder} placeholder is not found in query
     """
+    if replacements is None:
+        replacements = {}
+
     # Use query from constants if none provided
     if query is None:
         query = TemplateConstants.QUERY.value

--- a/pipelines/rj_crm__disparo_template/utils/schemas.py
+++ b/pipelines/rj_crm__disparo_template/utils/schemas.py
@@ -8,7 +8,7 @@ Define estruturas de dados padronizadas com validação rigorosa usando Pydantic
 
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 
 
 class DestinationInput(BaseModel):
@@ -16,19 +16,20 @@ class DestinationInput(BaseModel):
     Schema para validação de dados de entrada (origem BigQuery)
 
     Campos obrigatórios:
-    - to: Número de telefone (formato validado em etapa anterior)
-    - externalId: Identificador externo único e não vazio
+    - telefone: Número de telefone (formato validado em etapa anterior)
+    - cpf: CPF do cidadão, identificador externo único e não vazio
 
     Campos opcionais:
     - vars: Dicionário flexível com variáveis para o template HSM
     """
 
-    to: str = Field(..., description="Número de telefone (formato validado em etapa anterior)")
-    externalId: str = Field(..., min_length=1, description="Identificador externo obrigatório")
+    telefone: str = Field(..., description="Número de telefone (formato validado em etapa anterior)")
+    cpf: str = Field(..., min_length=1, description="CPF do cidadão, identificador externo obrigatório")
     vars: Optional[Dict[str, Any]] = Field(default=None, description="Variáveis opcionais para template HSM")
     others: List[str] = Field(default_factory=list, description="Lista de telefones secundários para retentativas")
 
-    @validator("to")
+    @field_validator("telefone")
+    @classmethod
     def validate_phone(cls, v):
         """
         Valida que o telefone seja uma string não vazia
@@ -51,25 +52,26 @@ class DestinationInput(BaseModel):
 
         return v.strip()
 
-    @validator("externalId")
+    @field_validator("cpf")
+    @classmethod
     def validate_external_id(cls, v):
         """
-        Valida que externalId não seja vazio ou apenas espaços
+        Valida que cpf não seja vazio ou apenas espaços
 
         Args:
-            v: String do externalId a ser validada
+            v: String do cpf a ser validada
 
         Returns:
-            String do externalId validada
+            String do cpf validada
 
         Raises:
             ValueError: Se for vazio ou apenas espaços
         """
         if not isinstance(v, str):
-            raise ValueError("externalId deve ser uma string")
+            raise ValueError("cpf deve ser uma string")
 
         if not v.strip():
-            raise ValueError("externalId não pode ser vazio ou apenas espaços")
+            raise ValueError("cpf não pode ser vazio ou apenas espaços")
 
         return v.strip()
 
@@ -88,7 +90,8 @@ class DispatchPayload(BaseModel):
     costCenterId: int = Field(..., gt=0, description="ID do centro de custo (deve ser positivo)")
     destinations: List[DestinationInput] = Field(..., description="Lista de destinatários validados")
 
-    @validator("campaignName")
+    @field_validator("campaignName")
+    @classmethod
     def validate_campaign_name(cls, v):
         """
         Valida que o nome da campanha não seja apenas espaços
@@ -107,7 +110,8 @@ class DispatchPayload(BaseModel):
 
         return v.strip()
 
-    @validator("destinations")
+    @field_validator("destinations")
+    @classmethod
     def validate_destinations_not_empty(cls, v):
         """
         Valida que a lista de destinatários não esteja vazia
@@ -138,8 +142,8 @@ class DispatchRecord(BaseModel):
     dispatch_date: str = Field(..., description="Data e hora do disparo")
     campaignName: str = Field(..., description="Nome da campanha")
     costCenterId: int = Field(..., description="ID do centro de custo")
-    to: str = Field(..., description="Número de telefone do destinatário")
-    externalId: str = Field(..., description="Identificador externo do destinatário")
+    telefone: str = Field(..., description="Número de telefone do destinatário")
+    cpf: str = Field(..., description="CPF do cidadão")
     vars: Optional[Dict[str, Any]] = Field(default=None, description="Variáveis utilizadas no template")
 
 
@@ -150,7 +154,7 @@ class SfDispatchRow(BaseModel):
     Campos obrigatórios:
     - dispatch_date: Data e hora do disparo
     - campaign_name: Nome da campanha
-    - SubscriberKey: Chave do assinante no Salesforce (case-sensitive)
+    - cpf: CPF do cidadão (coluna interna do flow; renomeada para SubscriberKey apenas na escrita)
     - telefone: Número de telefone disparado
 
     A coluna `data` (JSON com demais campos) é construída pelo create_log_df,
@@ -159,24 +163,27 @@ class SfDispatchRow(BaseModel):
 
     dispatch_date: str = Field(..., description="Data e hora do disparo")
     campaign_name: str = Field(..., min_length=1, description="Nome da campanha")
-    SubscriberKey: str = Field(..., min_length=1, description="Chave do assinante no Salesforce")
+    cpf: str = Field(..., min_length=1, description="CPF do cidadão")
     telefone: str = Field(..., min_length=1, description="Número de telefone disparado")
 
-    @validator("campaign_name")
+    @field_validator("campaign_name")
+    @classmethod
     def validate_campaign_name(cls, v):
         if not v.strip():
             raise ValueError("campaign_name não pode ser vazio ou apenas espaços")
         return v.strip()
 
-    @validator("SubscriberKey")
-    def validate_subscriber_key(cls, v):
+    @field_validator("cpf")
+    @classmethod
+    def validate_cpf(cls, v):
         if not isinstance(v, str):
-            raise ValueError("SubscriberKey deve ser uma string")
+            raise ValueError("cpf deve ser uma string")
         if not v.strip():
-            raise ValueError("SubscriberKey não pode ser vazio ou apenas espaços")
+            raise ValueError("cpf não pode ser vazio ou apenas espaços")
         return v.strip()
 
-    @validator("telefone")
+    @field_validator("telefone")
+    @classmethod
     def validate_telefone(cls, v):
         if not isinstance(v, str):
             raise ValueError("telefone deve ser uma string")

--- a/pipelines/rj_crm__disparo_template/utils/tasks.py
+++ b/pipelines/rj_crm__disparo_template/utils/tasks.py
@@ -73,11 +73,12 @@ def safe_export_df_to_parquet(
     Returns:
         str: The path to the output Parquet file.
     """
-    # Create directory if it doesn't exist
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    # Create directory if it doesn't exist (dirname returns "" for bare filenames)
+    output_dir = os.path.dirname(output_path) or "."
+    os.makedirs(output_dir, exist_ok=True)
     # Generate a unique filename using uuid
     filename = f"{uuid.uuid4()}.csv"
-    csv_path = os.path.join(os.path.dirname(output_path), filename)
+    csv_path = os.path.join(output_dir, filename)
     dfr.to_csv(csv_path, index=False)
     parquet_path = csv_path.replace(".csv", ".parquet")
 
@@ -144,7 +145,7 @@ def create_date_partitions(
         elif file_format == "parquet":
             safe_export_df_to_parquet(dfr=_dataframe, output_path=file_folder)
 
-    log(f"Files saved on root_folder{root_folder} as {file_folder}")
+    log(f"Files saved on root_folder={root_folder} as {file_folder}")
     return root_folder
 
 
@@ -201,9 +202,7 @@ def download_data_from_bigquery(query: str, billing_project_id: str, bucket_name
     job = bq_client.query(query)
     while not job.done():
         sleep(1)
-    log("Getting result from query")
     results = job.result()
-    log("Converting result to pandas dataframe")
     dfr = results.to_dataframe()
     log("End download data from bigquery")
     return dfr

--- a/pipelines/rj_crm__disparo_template/utils/validators.py
+++ b/pipelines/rj_crm__disparo_template/utils/validators.py
@@ -73,8 +73,9 @@ def validate_destinations(destinations: List[Dict]) -> Tuple[List[DestinationInp
             if isinstance(to_partial, str) and len(to_partial) > 8:
                 to_partial = to_partial[:8] + "****"
 
-            cpf = destination.get("cpf", "N/A")
-            log(f"Destinatário inválido - telefone: {to_partial}, cpf: {cpf}, erros: {error_msg}")
+            cpf_raw = destination.get("cpf", "N/A")
+            cpf_partial = cpf_raw[:4] + "****" if isinstance(cpf_raw, str) and len(cpf_raw) > 4 else cpf_raw
+            log(f"Destinatário inválido - telefone: {to_partial}, cpf: {cpf_partial}, erros: {error_msg}")
 
         except Exception as e:
             # Erro inesperado durante validação
@@ -287,9 +288,9 @@ def validate_campaign_name(
 
     if total == 0:
         message = f"""
-            ATENÇÃO: campaign_name='{campaign_name}' não encontrado na coluna hsm.nome_hsm "
-            "da tabela rj-crm-registry.brutos_salesforce.jornada. "
-            "Verifique o nome da campanha e tente novamente. Encerrando o flow."
+            ATENÇÃO: campaign_name='{campaign_name}' não encontrado na coluna hsm.nome_hsm
+            da tabela rj-crm-registry.brutos_salesforce.jornada.
+            Verifique o nome da campanha e tente novamente. Encerrando o flow.
         """
         log(message)
         webhook_url = os.getenv("DISCORD_WEBHOOK_URL_ERRORS")

--- a/pipelines/rj_crm__disparo_template/utils/validators.py
+++ b/pipelines/rj_crm__disparo_template/utils/validators.py
@@ -7,12 +7,14 @@ Funções centralizadas de validação para pipeline de template
 Implementa validação robusta com logs detalhados e métricas de qualidade
 """
 
+import os
 from typing import Dict, List, Optional, Tuple
 
 import pandas as pd
 from iplanrio.pipelines_utils.logging import log  # pylint: disable=E0611, E0401
 from pydantic import ValidationError
 
+from pipelines.rj_crm__disparo_template.utils.discord import send_discord_notification  # pylint: disable=E0611, E0401
 # pylint: disable=E0611, E0401
 from pipelines.rj_crm__disparo_template.utils.schemas import (
     DestinationInput,
@@ -67,12 +69,12 @@ def validate_destinations(destinations: List[Dict]) -> Tuple[List[DestinationInp
             validation_errors.append(error_msg)
 
             # Log do destinatário inválido (sem dados sensíveis completos)
-            to_partial = destination.get("to", "N/A")
+            to_partial = destination.get("telefone", "N/A")
             if isinstance(to_partial, str) and len(to_partial) > 8:
                 to_partial = to_partial[:8] + "****"
 
-            external_id = destination.get("externalId", "N/A")
-            log(f"Destinatário inválido - to: {to_partial}, externalId: {external_id}, erros: {error_msg}")
+            cpf = destination.get("cpf", "N/A")
+            log(f"Destinatário inválido - telefone: {to_partial}, cpf: {cpf}, erros: {error_msg}")
 
         except Exception as e:
             # Erro inesperado durante validação
@@ -152,7 +154,7 @@ def validate_dispatch_payload(
 
         error_msg = f"Payload inválido: {'; '.join(error_details)}"
         log(f"ERRO: {error_msg}")
-        raise ValidationError(error_msg)
+        raise
 
 
 def log_validation_summary(stats: ValidationStats, context: str = ""):
@@ -185,7 +187,7 @@ def log_validation_summary(stats: ValidationStats, context: str = ""):
 def validate_sf_dataframe(df: pd.DataFrame, campaign_name: str) -> pd.DataFrame:
     """
     Valida que o DataFrame retornado pela query possui as colunas obrigatórias
-    para o flow SF: SubscriberKey e telefone.
+    para o flow SF: cpf e telefone.
 
     Deve ser chamada logo após a checagem de df vazio no flow, antes de qualquer
     processamento. Se alguma coluna obrigatória estiver ausente, lança ValueError
@@ -199,16 +201,16 @@ def validate_sf_dataframe(df: pd.DataFrame, campaign_name: str) -> pd.DataFrame:
         O próprio DataFrame sem modificações
 
     Raises:
-        ValueError: Se SubscriberKey, telefone ou campaign_name estiverem ausentes/inválidos
+        ValueError: Se cpf, telefone ou campaign_name estiverem ausentes/inválidos
     """
-    required_columns = ["SubscriberKey", "telefone"]
+    required_columns = ["cpf", "telefone"]
     missing = [col for col in required_columns if col not in df.columns]
 
     if missing:
         raise ValueError(
             f"O DataFrame não possui as colunas obrigatórias para o log SF: {missing}. "
             f"Colunas presentes: {list(df.columns)}. "
-            "Verifique se a query retorna 'SubscriberKey' e 'telefone'."
+            "Verifique se a query retorna 'cpf' e 'telefone'."
         )
 
     if not campaign_name or not str(campaign_name).strip():
@@ -225,7 +227,7 @@ def validate_sf_dataframe(df: pd.DataFrame, campaign_name: str) -> pd.DataFrame:
             SfDispatchRow(
                 dispatch_date="2000-01-01",  # placeholder para validação estrutural
                 campaign_name=str(campaign_name),
-                SubscriberKey=str(row.get("SubscriberKey", "")),
+                cpf=str(row.get("cpf", "")),
                 telefone=str(row.get("telefone", "")),
             )
         except ValidationError as e:
@@ -284,15 +286,17 @@ def validate_campaign_name(
     total = results[0]["total"] if results else 0
 
     if total == 0:
-        log(
-            f"ATENÇÃO: campaign_name='{campaign_name}' não encontrado na coluna hsm.nome_hsm "
+        message = f"""
+            ATENÇÃO: campaign_name='{campaign_name}' não encontrado na coluna hsm.nome_hsm "
             "da tabela rj-crm-registry.brutos_salesforce.jornada. "
-            "Verifique o nome da campanha e tente novamente."
-        )
-        print(
-            f"[validate_campaign_name_in_bigquery] campaign_name='{campaign_name}' não existe "
-            "em rj-crm-registry.brutos_salesforce.jornada (hsm.nome_hsm). Encerrando o flow."
-        )
+            "Verifique o nome da campanha e tente novamente. Encerrando o flow."
+        """
+        log(message)
+        webhook_url = os.getenv("DISCORD_WEBHOOK_URL_ERRORS")
+        if not webhook_url:
+            print("DISCORD_WEBHOOK_URL_ERRORS environment variable not set. Cannot send notification.")
+        else:
+            send_discord_notification(webhook_url, message)
         return None
 
     log(f"campaign_name='{campaign_name}' validado com sucesso ({total} registro(s) encontrado(s)).")

--- a/pipelines/rj_smas__cadunico/utils_dbt.py
+++ b/pipelines/rj_smas__cadunico/utils_dbt.py
@@ -56,7 +56,7 @@ def download_repository(git_repository_path: str, branch: str = "master") -> str
     try:
         repo = git.Repo.clone_from(git_repository_path, repository_path, branch=branch)
         log(
-            f"Repository downloaded: {git_repository_path} (branch: {branch})",
+            f"Repository downloaded successfully (branch: {branch})",
             level="info",
         )
         log(f"Current branch: {repo.active_branch.name}", level="info")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novos Recursos**
  * Notificações de falha passaram a ser enviadas ao Discord quando executado em produção e com webhook configurado.
  * Intervalo temporal configurável para controlar verificações e reduzir reenvios repetidos durante o retry.
  * Atualização do agendamento do disparo com placeholder de identificador legado no template.

* **Correções**
  * Padronização dos destinatários para usar telefone e CPF em validações, logs e payloads (incluindo whitelist e exportação).
  * Ajustes na deduplicação e no histórico de envios em tentativas, além de melhorias no tratamento de expiração e de falhas/quarentena.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->