### PR TITLE
fix: enrich_with_debitos_api usa "cpf" como coluna padrão de join

### DIFF
--- a/pipelines/rj_crm__disparo_template/utils/enrichers/consulta_debitos.py
+++ b/pipelines/rj_crm__disparo_template/utils/enrichers/consulta_debitos.py
@@ -165,16 +165,19 @@ def enrich_with_debitos_api(df: pd.DataFrame, params: dict = {}) -> pd.DataFrame
     não como JSON.
 
     Args:
-        df: DataFrame com uma coluna de CPF (default "SubscriberKey").
+        df: DataFrame com uma coluna de CPF (default "cpf" — nome interno padrão
+            usado pelo flow entre o download da query e o rename de volta pra
+            "SubscriberKey" logo antes do save_csv_for_sftp; é nesse trecho
+            interno que o enrichment roda).
         params: dict com chaves opcionais:
-            - cpf_column (default "SubscriberKey")
+            - cpf_column (default "cpf")
             - api_url (default DEFAULT_API_URL)
 
     Returns:
         DataFrame apenas com os CPFs que tiveram dívida confirmada, com as
         colunas acima anexadas.
     """
-    cpf_column = params.get("cpf_column", "SubscriberKey")
+    cpf_column = params.get("cpf_column", "cpf")
     api_url = params.get("api_url", DEFAULT_API_URL)
 
     cpfs = df[cpf_column].dropna().unique().tolist()


### PR DESCRIPTION
A branch staging/fix-disparo-v2 (PR #309) foi mergeada em paralelo e padronizou a coluna interna de CPF do flow pra "cpf" (renomeada de SubscriberKey logo após o download da query, e renomeada de volta pra SubscriberKey só no final, antes do save_csv_for_sftp). O enrichment de consulta_debitos roda nesse trecho intermediário, então precisa procurar "cpf", não "SubscriberKey" — daí o KeyError('SubscriberKey') em produção. cpfCnpj continua sendo adicionado normalmente.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * O enriquecimento de débitos agora usa `cpf` como coluna padrão, reduzindo a necessidade de configuração manual.
  * A documentação foi ajustada para refletir o novo valor padrão.
  * Ainda é possível sobrescrever o nome da coluna via parâmetros, mantendo flexibilidade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->