### PR TITLE
fix(rj_crm__run_dbt): evitar concorrência entre schedules quarter_hourly/12h

### DIFF
--- a/pipelines/rj_crm__run_dbt/prefect.yaml
+++ b/pipelines/rj_crm__run_dbt/prefect.yaml
@@ -38,6 +38,14 @@ deployments:
   - name: rj-crm--run_dbt--prod
     version: "{{ get-commit-hash.stdout }}"
     entrypoint: pipelines/rj_crm__run_dbt/flow.py:rj_crm__run_dbt
+    # Evita que duas schedules rodem em paralelo sobre os mesmos modelos.
+    # Ex.: dbt_12h_build e dbt_quarter_hourly_build compartilham o select
+    # "tag:quarter_hourly" e, quando coincidem, geram testes unique flaky
+    # (ex.: raw_superapp_mobile_originated_v2__id_mensagem__unique) por
+    # concorrência de escrita no mesmo modelo incremental.
+    concurrency_limit:
+      limit: 1
+      collision_strategy: ENQUEUE
     work_pool:
       name: default-pool
       work_queue_name: default


### PR DESCRIPTION
## Problema

A deployment `rj-crm--run_dbt--prod` (pipeline `pipelines/rj_crm__run_dbt`) tem 5 schedules, sendo duas delas concorrentes entre si:

- `dbt_12h_build` (a cada 12h) — `select: "tag:quarter_hourly"`
- `dbt_quarter_hourly_build` (a cada 15min) — `select: "tag:quarter_hourly --vars '{passe: quente}'"`

Ambas fazem build sobre o mesmo conjunto de modelos (`tag:quarter_hourly`, que inclui `raw_superapp_mobile_originated_v2` → `int_chatbot_v2_mensagens_enviadas`). Quando as janelas coincidem, uma execução sobrescreve o modelo incremental enquanto a outra roda os testes, gerando falhas intermitentes como:

```
rj-crm--run-dbt quebrou para a tabela int_chatbot_v2_mensagens_enviadas
teste: raw_superapp_mobile_originated_v2__id_mensagem__unique
```

Erro mapeado como inofensivo (não é corrupção de dado, é concorrência de escrita/leitura), reportado no canal de dados.

## Correção

Adiciona `concurrency_limit` na deployment `rj-crm--run_dbt--prod`:

```yaml
concurrency_limit:
  limit: 1
  collision_strategy: ENQUEUE
```

Isso serializa as runs da deployment: se uma schedule disparar enquanto outra ainda está em execução, a nova fica em `AwaitingConcurrencySlot` e roda automaticamente assim que a anterior terminar — sem cancelar nem perder execuções, só remove a concorrência.

## Nota

Este limite serializa as 5 schedules dessa deployment (daily, weekly, 12h, 15min), não só as duas que colidem. Como são builds dbt idempotentes e rápidos, o trade-off é seguro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Melhorias**
  * A implantação de produção agora executa apenas uma tarefa por vez.
  * Execuções simultâneas são enfileiradas automaticamente para processamento posterior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->