### PR TITLE
feat(rj_crm__disparo_template): sempre trazer maternidade nas queries de puérperas

### DIFF
--- a/pipelines/rj_crm__disparo_template/prefect.yaml
+++ b/pipelines/rj_crm__disparo_template/prefect.yaml
@@ -653,7 +653,7 @@ deployments:
           dataset_id: brutos_salesforce
           campaign_name: smspuerperasdisparo25
           data_extension_filename: whatsapp_sms_puerperas_explica_pesquisa
-          de_columns: ["nome"]
+          de_columns: ["nome", "maternidade"]
           max_dispatch_retries: 0
           sleep_minutes: 5
           whitelist_percentage: 0
@@ -666,16 +666,17 @@ deployments:
           force_add_on_whitelist_group: true
           whitelist_replace_contacts: true
           query: "WITH segmentacao_original AS (\n    SELECT\n        lpad(cast(cpf
-            as string) , 11, '0') as cpf,\n        nome,\n        data_alta_internacao,\n\
-            \        telefones_gestante,\n    FROM `rj-sms.projeto_whatsapp.sisare_alta_maternidade`\n\
-            \    -- from `rj-crm-registry-dev.brutos_sms.sisare_alta_maternidade_teste`\n\
-            \    WHERE cpf is not null\n        and cpf != '00000000000'\n    AND
-            DATE(data_alta_internacao) between\n            DATE_SUB(CURRENT_DATE('America/Sao_Paulo'),
-            INTERVAL 2 DAY) and CURRENT_DATE('America/Sao_Paulo')\n            and
-            nome_maternidade_alta like '%MARIA AMELIA%' -- todo: remover comentario\n\
-            \    ),\n    telefones as (\n    select \n        lpad(cast(cpf as string)
-            , 11, '0') as cpf,\n        nome,\n        MAX(data_alta_internacao) as
-            data_alta_internacao,\n        MAX(IF(telefone.prioridade = '1', telefone.telefone_valido_whatsapp,
+            as string) , 11, '0') as cpf,\n        nome,\n        nome_maternidade_alta
+            AS maternidade,\n        data_alta_internacao,\n        telefones_gestante,\n\
+            \    FROM `rj-sms.projeto_whatsapp.sisare_alta_maternidade`\n    -- from
+            `rj-crm-registry-dev.brutos_sms.sisare_alta_maternidade_teste`\n    WHERE
+            cpf is not null\n        and cpf != '00000000000'\n    AND DATE(data_alta_internacao)
+            between\n            DATE_SUB(CURRENT_DATE('America/Sao_Paulo'), INTERVAL
+            2 DAY) and CURRENT_DATE('America/Sao_Paulo')\n            and nome_maternidade_alta
+            like '%MARIA AMELIA%' -- todo: remover comentario\n    ),\n    telefones
+            as (\n    select\n        lpad(cast(cpf as string) , 11, '0') as cpf,\n\
+            \        nome,\n        MAX(maternidade) as maternidade,\n        MAX(data_alta_internacao)
+            as data_alta_internacao,\n        MAX(IF(telefone.prioridade = '1', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_1,\n        MAX(IF(telefone.prioridade = '2',
             telefone.telefone_valido_whatsapp, NULL)) AS celular_disparo_2,\n    \
             \    MAX(IF(telefone.prioridade = '3', telefone.telefone_valido_whatsapp,
@@ -738,9 +739,9 @@ deployments:
             AS externalId,\n        INITCAP(\n            IF(\n                ARRAY_LENGTH(SPLIT(nome,
             ' ')) > 1,\n                CONCAT(SPLIT(nome, ' ')[SAFE_OFFSET(0)], '
             '),\n                nome\n            )\n        ) AS nome,\n       \
-            \ ARRAY(SELECT x FROM UNNEST([celular_disparo_2, celular_disparo_3]) AS
-            x WHERE x IS NOT NULL AND x != celular_disparo) AS others\n    from final\n\
-            \    where celular_disparo is not null\n"
+            \ maternidade,\n        ARRAY(SELECT x FROM UNNEST([celular_disparo_2,
+            celular_disparo_3]) AS x WHERE x IS NOT NULL AND x != celular_disparo)
+            AS others\n    from final\n    where celular_disparo is not null\n"
       - cron: "0 10 * * *"
         timezone: America/Sao_Paulo
         active: false
@@ -772,7 +773,7 @@ deployments:
           dataset_id: brutos_salesforce
           campaign_name: smspuerperasdisparo4v3
           data_extension_filename: whatsapp_sms_puerperas_pesquisa1
-          de_columns: ["nome"]
+          de_columns: ["nome", "maternidade"]
           max_dispatch_retries: 0
           sleep_minutes: 5
           whitelist_percentage: 0
@@ -786,14 +787,15 @@ deployments:
           whitelist_replace_contacts: true
           query: "-- {pesquisa_id}\nWITH segmentacao_original AS (\n    SELECT\n \
             \       lpad(cast(cpf as string) , 11, '0') as cpf,\n        nome,\n \
-            \       data_alta_internacao,\n        telefones_gestante\n    FROM `rj-sms.projeto_whatsapp.sisare_alta_maternidade`\n\
+            \       nome_maternidade_alta AS maternidade,\n        data_alta_internacao,\n\
+            \        telefones_gestante\n    FROM `rj-sms.projeto_whatsapp.sisare_alta_maternidade`\n\
             \    -- from `rj-crm-registry-dev.brutos_sms.sisare_alta_maternidade_teste`\n\
             \    WHERE cpf is not null\n        and cpf != '00000000000'\n    AND
             CURRENT_DATE('America/Sao_Paulo') in\n        (\n        {datas_internacao}\n\
             \        )\n        and nome_maternidade_alta like '%MARIA AMELIA%'\n
             ),\ntelefones as (\nselect\n    lpad(cast(cpf as string) , 11, '0') as
-            cpf,\n    nome,\n    MAX(data_alta_internacao) as data_alta_internacao,\n\
-            \    MAX(IF(telefone.prioridade = '1', telefone.telefone_valido_whatsapp,
+            cpf,\n    nome,\n    MAX(maternidade) as maternidade,\n    MAX(data_alta_internacao)
+            as data_alta_internacao,\n    MAX(IF(telefone.prioridade = '1', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_1,\n    MAX(IF(telefone.prioridade = '2', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_2,\n    MAX(IF(telefone.prioridade = '3', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_3\nFROM segmentacao_original,\nUNNEST(telefones_gestante)
@@ -872,10 +874,11 @@ deployments:
             \    CAST(cpf AS STRING) AS externalId,\n    INITCAP(\n        IF(\n \
             \           ARRAY_LENGTH(SPLIT(nome, ' ')) > 1,\n            CONCAT(SPLIT(nome,
             ' ')[SAFE_OFFSET(0)], ' '),\n            nome\n        )\n    ) AS nome,\n\
-            \    CAST(DATE_DIFF(CURRENT_DATE('America/Sao_Paulo'), DATE(data_alta_internacao),
-            DAY) AS STRING) AS numero_dias,\n    ARRAY(SELECT x FROM UNNEST([celular_disparo_2,
-            celular_disparo_3]) AS x WHERE x IS NOT NULL AND x != celular_disparo)
-            AS others\nfrom final\nwhere celular_disparo is not null\n"
+            \    maternidade,\n    CAST(DATE_DIFF(CURRENT_DATE('America/Sao_Paulo'),
+            DATE(data_alta_internacao), DAY) AS STRING) AS numero_dias,\n    ARRAY(SELECT
+            x FROM UNNEST([celular_disparo_2, celular_disparo_3]) AS x WHERE x IS
+            NOT NULL AND x != celular_disparo) AS others\nfrom final\nwhere celular_disparo
+            is not null\n"
       - cron: "0 10 * * *"
         timezone: America/Sao_Paulo
         active: false
@@ -899,7 +902,7 @@ deployments:
           dataset_id: brutos_salesforce
           campaign_name: smspuerperadisparo6
           data_extension_filename: whatsapp_sms_puerperas_pesquisa4
-          de_columns: ["nome", "numero_dias"] # única pesquisa cuja hsm usa a variável numero_dias
+          de_columns: ["nome", "numero_dias", "maternidade"] # única pesquisa cuja hsm usa a variável numero_dias
           max_dispatch_retries: 0
           sleep_minutes: 5
           whitelist_percentage: 0
@@ -913,14 +916,15 @@ deployments:
           whitelist_replace_contacts: true
           query: "-- {pesquisa_id}\nWITH segmentacao_original AS (\n    SELECT\n \
             \       lpad(cast(cpf as string) , 11, '0') as cpf,\n        nome,\n \
-            \       data_alta_internacao,\n        telefones_gestante\n    FROM `rj-sms.projeto_whatsapp.sisare_alta_maternidade`\n\
+            \       nome_maternidade_alta AS maternidade,\n        data_alta_internacao,\n\
+            \        telefones_gestante\n    FROM `rj-sms.projeto_whatsapp.sisare_alta_maternidade`\n\
             \    -- from `rj-crm-registry-dev.brutos_sms.sisare_alta_maternidade_teste`\n\
             \    WHERE cpf is not null\n        and cpf != '00000000000'\n    AND
             CURRENT_DATE('America/Sao_Paulo') in\n        (\n        {datas_internacao}\n\
             \        )\n        and nome_maternidade_alta like '%MARIA AMELIA%'\n
             ),\ntelefones as (\nselect\n    lpad(cast(cpf as string) , 11, '0') as
-            cpf,\n    nome,\n    MAX(data_alta_internacao) as data_alta_internacao,\n\
-            \    MAX(IF(telefone.prioridade = '1', telefone.telefone_valido_whatsapp,
+            cpf,\n    nome,\n    MAX(maternidade) as maternidade,\n    MAX(data_alta_internacao)
+            as data_alta_internacao,\n    MAX(IF(telefone.prioridade = '1', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_1,\n    MAX(IF(telefone.prioridade = '2', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_2,\n    MAX(IF(telefone.prioridade = '3', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_3\nFROM segmentacao_original,\nUNNEST(telefones_gestante)
@@ -999,10 +1003,11 @@ deployments:
             \    CAST(cpf AS STRING) AS externalId,\n    INITCAP(\n        IF(\n \
             \           ARRAY_LENGTH(SPLIT(nome, ' ')) > 1,\n            CONCAT(SPLIT(nome,
             ' ')[SAFE_OFFSET(0)], ' '),\n            nome\n        )\n    ) AS nome,\n\
-            \    CAST(DATE_DIFF(CURRENT_DATE('America/Sao_Paulo'), DATE(data_alta_internacao),
-            DAY) AS STRING) AS numero_dias,\n    ARRAY(SELECT x FROM UNNEST([celular_disparo_2,
-            celular_disparo_3]) AS x WHERE x IS NOT NULL AND x != celular_disparo)
-            AS others\nfrom final\nwhere celular_disparo is not null\n"
+            \    maternidade,\n    CAST(DATE_DIFF(CURRENT_DATE('America/Sao_Paulo'),
+            DATE(data_alta_internacao), DAY) AS STRING) AS numero_dias,\n    ARRAY(SELECT
+            x FROM UNNEST([celular_disparo_2, celular_disparo_3]) AS x WHERE x IS
+            NOT NULL AND x != celular_disparo) AS others\nfrom final\nwhere celular_disparo
+            is not null\n"
       - cron: "0 10 * * *"
         timezone: America/Sao_Paulo
         active: false
@@ -1028,7 +1033,7 @@ deployments:
           dataset_id: brutos_salesforce
           campaign_name: smspuerperasdisparo12
           data_extension_filename: whatsapp_sms_puerperas_pesquisa5
-          de_columns: ["nome"]
+          de_columns: ["nome", "maternidade"]
           max_dispatch_retries: 0
           sleep_minutes: 5
           whitelist_percentage: 0
@@ -1042,14 +1047,15 @@ deployments:
           whitelist_replace_contacts: true
           query: "-- {pesquisa_id}\nWITH segmentacao_original AS (\n    SELECT\n \
             \       lpad(cast(cpf as string) , 11, '0') as cpf,\n        nome,\n \
-            \       data_alta_internacao,\n        telefones_gestante\n    FROM `rj-sms.projeto_whatsapp.sisare_alta_maternidade`\n\
+            \       nome_maternidade_alta AS maternidade,\n        data_alta_internacao,\n\
+            \        telefones_gestante\n    FROM `rj-sms.projeto_whatsapp.sisare_alta_maternidade`\n\
             \    -- from `rj-crm-registry-dev.brutos_sms.sisare_alta_maternidade_teste`\n\
             \    WHERE cpf is not null\n        and cpf != '00000000000'\n    AND
             CURRENT_DATE('America/Sao_Paulo') in\n        (\n        {datas_internacao}\n\
             \        )\n        and nome_maternidade_alta like '%MARIA AMELIA%'\n
             ),\ntelefones as (\nselect\n    lpad(cast(cpf as string) , 11, '0') as
-            cpf,\n    nome,\n    MAX(data_alta_internacao) as data_alta_internacao,\n\
-            \    MAX(IF(telefone.prioridade = '1', telefone.telefone_valido_whatsapp,
+            cpf,\n    nome,\n    MAX(maternidade) as maternidade,\n    MAX(data_alta_internacao)
+            as data_alta_internacao,\n    MAX(IF(telefone.prioridade = '1', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_1,\n    MAX(IF(telefone.prioridade = '2', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_2,\n    MAX(IF(telefone.prioridade = '3', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_3\nFROM segmentacao_original,\nUNNEST(telefones_gestante)
@@ -1128,10 +1134,11 @@ deployments:
             \    CAST(cpf AS STRING) AS externalId,\n    INITCAP(\n        IF(\n \
             \           ARRAY_LENGTH(SPLIT(nome, ' ')) > 1,\n            CONCAT(SPLIT(nome,
             ' ')[SAFE_OFFSET(0)], ' '),\n            nome\n        )\n    ) AS nome,\n\
-            \    CAST(DATE_DIFF(CURRENT_DATE('America/Sao_Paulo'), DATE(data_alta_internacao),
-            DAY) AS STRING) AS numero_dias,\n    ARRAY(SELECT x FROM UNNEST([celular_disparo_2,
-            celular_disparo_3]) AS x WHERE x IS NOT NULL AND x != celular_disparo)
-            AS others\nfrom final\nwhere celular_disparo is not null\n"
+            \    maternidade,\n    CAST(DATE_DIFF(CURRENT_DATE('America/Sao_Paulo'),
+            DATE(data_alta_internacao), DAY) AS STRING) AS numero_dias,\n    ARRAY(SELECT
+            x FROM UNNEST([celular_disparo_2, celular_disparo_3]) AS x WHERE x IS
+            NOT NULL AND x != celular_disparo) AS others\nfrom final\nwhere celular_disparo
+            is not null\n"
       - cron: "0 10 * * *"
         timezone: America/Sao_Paulo
         active: false
@@ -1153,7 +1160,7 @@ deployments:
           dataset_id: brutos_salesforce
           campaign_name: smspuerperasdisparo152
           data_extension_filename: whatsapp_sms_puerperas_pesquisa7
-          de_columns: ["nome"]
+          de_columns: ["nome", "maternidade"]
           max_dispatch_retries: 0
           sleep_minutes: 5
           whitelist_percentage: 0
@@ -1167,14 +1174,15 @@ deployments:
           whitelist_replace_contacts: true
           query: "-- {pesquisa_id}\nWITH segmentacao_original AS (\n    SELECT\n \
             \       lpad(cast(cpf as string) , 11, '0') as cpf,\n        nome,\n \
-            \       data_alta_internacao,\n        telefones_gestante\n    FROM `rj-sms.projeto_whatsapp.sisare_alta_maternidade`\n\
+            \       nome_maternidade_alta AS maternidade,\n        data_alta_internacao,\n\
+            \        telefones_gestante\n    FROM `rj-sms.projeto_whatsapp.sisare_alta_maternidade`\n\
             \    -- from `rj-crm-registry-dev.brutos_sms.sisare_alta_maternidade_teste`\n\
             \    WHERE cpf is not null\n        and cpf != '00000000000'\n    AND
             CURRENT_DATE('America/Sao_Paulo') in\n        (\n        {datas_internacao}\n\
             \        )\n        and nome_maternidade_alta like '%MARIA AMELIA%'\n
             ),\ntelefones as (\nselect\n    lpad(cast(cpf as string) , 11, '0') as
-            cpf,\n    nome,\n    MAX(data_alta_internacao) as data_alta_internacao,\n\
-            \    MAX(IF(telefone.prioridade = '1', telefone.telefone_valido_whatsapp,
+            cpf,\n    nome,\n    MAX(maternidade) as maternidade,\n    MAX(data_alta_internacao)
+            as data_alta_internacao,\n    MAX(IF(telefone.prioridade = '1', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_1,\n    MAX(IF(telefone.prioridade = '2', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_2,\n    MAX(IF(telefone.prioridade = '3', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_3\nFROM segmentacao_original,\nUNNEST(telefones_gestante)
@@ -1253,10 +1261,11 @@ deployments:
             \    CAST(cpf AS STRING) AS externalId,\n    INITCAP(\n        IF(\n \
             \           ARRAY_LENGTH(SPLIT(nome, ' ')) > 1,\n            CONCAT(SPLIT(nome,
             ' ')[SAFE_OFFSET(0)], ' '),\n            nome\n        )\n    ) AS nome,\n\
-            \    CAST(DATE_DIFF(CURRENT_DATE('America/Sao_Paulo'), DATE(data_alta_internacao),
-            DAY) AS STRING) AS numero_dias,\n    ARRAY(SELECT x FROM UNNEST([celular_disparo_2,
-            celular_disparo_3]) AS x WHERE x IS NOT NULL AND x != celular_disparo)
-            AS others\nfrom final\nwhere celular_disparo is not null\n"
+            \    maternidade,\n    CAST(DATE_DIFF(CURRENT_DATE('America/Sao_Paulo'),
+            DATE(data_alta_internacao), DAY) AS STRING) AS numero_dias,\n    ARRAY(SELECT
+            x FROM UNNEST([celular_disparo_2, celular_disparo_3]) AS x WHERE x IS
+            NOT NULL AND x != celular_disparo) AS others\nfrom final\nwhere celular_disparo
+            is not null\n"
       - cron: "0 13 * * *"
         timezone: America/Sao_Paulo
         active: false
@@ -2200,7 +2209,7 @@ deployments:
           dataset_id: brutos_salesforce
           campaign_name: smspuerperasdisparo25
           data_extension_filename: whatsapp_sms_puerperas_explica_pesquisa
-          de_columns: ["nome"]
+          de_columns: ["nome", "maternidade"]
           max_dispatch_retries: 0
           sleep_minutes: 5
           whitelist_percentage: 0
@@ -2213,16 +2222,17 @@ deployments:
           force_add_on_whitelist_group: true
           whitelist_replace_contacts: true
           query: "WITH segmentacao_original AS (\n    SELECT\n        lpad(cast(cpf
-            as string) , 11, '0') as cpf,\n        nome,\n        data_alta_internacao,\n\
-            \        telefones_gestante,\n    FROM `rj-sms.projeto_whatsapp.sisare_alta_maternidade`\n\
-            \    -- from `rj-crm-registry-dev.brutos_sms.sisare_alta_maternidade_teste`\n\
-            \    WHERE cpf is not null\n        and cpf != '00000000000'\n    AND
-            DATE(data_alta_internacao) between\n            DATE_SUB(CURRENT_DATE('America/Sao_Paulo'),
-            INTERVAL 2 DAY) and CURRENT_DATE('America/Sao_Paulo')\n            and
-            nome_maternidade_alta like '%MARIA AMELIA%' -- todo: remover comentario\n\
-            \    ),\n    telefones as (\n    select \n        lpad(cast(cpf as string)
-            , 11, '0') as cpf,\n        nome,\n        MAX(data_alta_internacao) as
-            data_alta_internacao,\n        MAX(IF(telefone.prioridade = '1', telefone.telefone_valido_whatsapp,
+            as string) , 11, '0') as cpf,\n        nome,\n        nome_maternidade_alta
+            AS maternidade,\n        data_alta_internacao,\n        telefones_gestante,\n\
+            \    FROM `rj-sms.projeto_whatsapp.sisare_alta_maternidade`\n    -- from
+            `rj-crm-registry-dev.brutos_sms.sisare_alta_maternidade_teste`\n    WHERE
+            cpf is not null\n        and cpf != '00000000000'\n    AND DATE(data_alta_internacao)
+            between\n            DATE_SUB(CURRENT_DATE('America/Sao_Paulo'), INTERVAL
+            2 DAY) and CURRENT_DATE('America/Sao_Paulo')\n            and nome_maternidade_alta
+            like '%MARIA AMELIA%' -- todo: remover comentario\n    ),\n    telefones
+            as (\n    select\n        lpad(cast(cpf as string) , 11, '0') as cpf,\n\
+            \        nome,\n        MAX(maternidade) as maternidade,\n        MAX(data_alta_internacao)
+            as data_alta_internacao,\n        MAX(IF(telefone.prioridade = '1', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_1,\n        MAX(IF(telefone.prioridade = '2',
             telefone.telefone_valido_whatsapp, NULL)) AS celular_disparo_2,\n    \
             \    MAX(IF(telefone.prioridade = '3', telefone.telefone_valido_whatsapp,
@@ -2285,9 +2295,9 @@ deployments:
             AS externalId,\n        INITCAP(\n            IF(\n                ARRAY_LENGTH(SPLIT(nome,
             ' ')) > 1,\n                CONCAT(SPLIT(nome, ' ')[SAFE_OFFSET(0)], '
             '),\n                nome\n            )\n        ) AS nome,\n       \
-            \ ARRAY(SELECT x FROM UNNEST([celular_disparo_2, celular_disparo_3]) AS
-            x WHERE x IS NOT NULL AND x != celular_disparo) AS others\n    from final\n\
-            \    where celular_disparo is not null\n"
+            \ maternidade,\n        ARRAY(SELECT x FROM UNNEST([celular_disparo_2,
+            celular_disparo_3]) AS x WHERE x IS NOT NULL AND x != celular_disparo)
+            AS others\n    from final\n    where celular_disparo is not null\n"
       - cron: "0 10 * * *"
         timezone: America/Sao_Paulo
         active: true
@@ -2319,7 +2329,7 @@ deployments:
           dataset_id: brutos_salesforce
           campaign_name: smspuerperasdisparo4v3
           data_extension_filename: whatsapp_sms_puerperas_pesquisa1
-          de_columns: ["nome"]
+          de_columns: ["nome", "maternidade"]
           max_dispatch_retries: 0
           sleep_minutes: 5
           whitelist_percentage: 0
@@ -2333,14 +2343,15 @@ deployments:
           whitelist_replace_contacts: true
           query: "-- {pesquisa_id}\nWITH segmentacao_original AS (\n    SELECT\n \
             \       lpad(cast(cpf as string) , 11, '0') as cpf,\n        nome,\n \
-            \       data_alta_internacao,\n        telefones_gestante\n    FROM `rj-sms.projeto_whatsapp.sisare_alta_maternidade`\n\
+            \       nome_maternidade_alta AS maternidade,\n        data_alta_internacao,\n\
+            \        telefones_gestante\n    FROM `rj-sms.projeto_whatsapp.sisare_alta_maternidade`\n\
             \    -- from `rj-crm-registry-dev.brutos_sms.sisare_alta_maternidade_teste`\n\
             \    WHERE cpf is not null\n        and cpf != '00000000000'\n    AND
             CURRENT_DATE('America/Sao_Paulo') in\n        (\n        {datas_internacao}\n\
             \        )\n        and nome_maternidade_alta like '%MARIA AMELIA%'\n
             ),\ntelefones as (\nselect\n    lpad(cast(cpf as string) , 11, '0') as
-            cpf,\n    nome,\n    MAX(data_alta_internacao) as data_alta_internacao,\n\
-            \    MAX(IF(telefone.prioridade = '1', telefone.telefone_valido_whatsapp,
+            cpf,\n    nome,\n    MAX(maternidade) as maternidade,\n    MAX(data_alta_internacao)
+            as data_alta_internacao,\n    MAX(IF(telefone.prioridade = '1', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_1,\n    MAX(IF(telefone.prioridade = '2', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_2,\n    MAX(IF(telefone.prioridade = '3', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_3\nFROM segmentacao_original,\nUNNEST(telefones_gestante)
@@ -2419,10 +2430,11 @@ deployments:
             \    CAST(cpf AS STRING) AS externalId,\n    INITCAP(\n        IF(\n \
             \           ARRAY_LENGTH(SPLIT(nome, ' ')) > 1,\n            CONCAT(SPLIT(nome,
             ' ')[SAFE_OFFSET(0)], ' '),\n            nome\n        )\n    ) AS nome,\n\
-            \    CAST(DATE_DIFF(CURRENT_DATE('America/Sao_Paulo'), DATE(data_alta_internacao),
-            DAY) AS STRING) AS numero_dias,\n    ARRAY(SELECT x FROM UNNEST([celular_disparo_2,
-            celular_disparo_3]) AS x WHERE x IS NOT NULL AND x != celular_disparo)
-            AS others\nfrom final\nwhere celular_disparo is not null\n"
+            \    maternidade,\n    CAST(DATE_DIFF(CURRENT_DATE('America/Sao_Paulo'),
+            DATE(data_alta_internacao), DAY) AS STRING) AS numero_dias,\n    ARRAY(SELECT
+            x FROM UNNEST([celular_disparo_2, celular_disparo_3]) AS x WHERE x IS
+            NOT NULL AND x != celular_disparo) AS others\nfrom final\nwhere celular_disparo
+            is not null\n"
       - cron: "0 10 * * *"
         timezone: America/Sao_Paulo
         active: true
@@ -2446,7 +2458,7 @@ deployments:
           dataset_id: brutos_salesforce
           campaign_name: smspuerperadisparo6
           data_extension_filename: whatsapp_sms_puerperas_pesquisa4
-          de_columns: ["nome", "numero_dias"] # única pesquisa cuja hsm usa a variável numero_dias
+          de_columns: ["nome", "numero_dias", "maternidade"] # única pesquisa cuja hsm usa a variável numero_dias
           max_dispatch_retries: 0
           sleep_minutes: 5
           whitelist_percentage: 0
@@ -2460,14 +2472,15 @@ deployments:
           whitelist_replace_contacts: true
           query: "-- {pesquisa_id}\nWITH segmentacao_original AS (\n    SELECT\n \
             \       lpad(cast(cpf as string) , 11, '0') as cpf,\n        nome,\n \
-            \       data_alta_internacao,\n        telefones_gestante\n    FROM `rj-sms.projeto_whatsapp.sisare_alta_maternidade`\n\
+            \       nome_maternidade_alta AS maternidade,\n        data_alta_internacao,\n\
+            \        telefones_gestante\n    FROM `rj-sms.projeto_whatsapp.sisare_alta_maternidade`\n\
             \    -- from `rj-crm-registry-dev.brutos_sms.sisare_alta_maternidade_teste`\n\
             \    WHERE cpf is not null\n        and cpf != '00000000000'\n    AND
             CURRENT_DATE('America/Sao_Paulo') in\n        (\n        {datas_internacao}\n\
             \        )\n        and nome_maternidade_alta like '%MARIA AMELIA%'\n
             ),\ntelefones as (\nselect\n    lpad(cast(cpf as string) , 11, '0') as
-            cpf,\n    nome,\n    MAX(data_alta_internacao) as data_alta_internacao,\n\
-            \    MAX(IF(telefone.prioridade = '1', telefone.telefone_valido_whatsapp,
+            cpf,\n    nome,\n    MAX(maternidade) as maternidade,\n    MAX(data_alta_internacao)
+            as data_alta_internacao,\n    MAX(IF(telefone.prioridade = '1', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_1,\n    MAX(IF(telefone.prioridade = '2', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_2,\n    MAX(IF(telefone.prioridade = '3', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_3\nFROM segmentacao_original,\nUNNEST(telefones_gestante)
@@ -2546,10 +2559,11 @@ deployments:
             \    CAST(cpf AS STRING) AS externalId,\n    INITCAP(\n        IF(\n \
             \           ARRAY_LENGTH(SPLIT(nome, ' ')) > 1,\n            CONCAT(SPLIT(nome,
             ' ')[SAFE_OFFSET(0)], ' '),\n            nome\n        )\n    ) AS nome,\n\
-            \    CAST(DATE_DIFF(CURRENT_DATE('America/Sao_Paulo'), DATE(data_alta_internacao),
-            DAY) AS STRING) AS numero_dias,\n    ARRAY(SELECT x FROM UNNEST([celular_disparo_2,
-            celular_disparo_3]) AS x WHERE x IS NOT NULL AND x != celular_disparo)
-            AS others\nfrom final\nwhere celular_disparo is not null\n"
+            \    maternidade,\n    CAST(DATE_DIFF(CURRENT_DATE('America/Sao_Paulo'),
+            DATE(data_alta_internacao), DAY) AS STRING) AS numero_dias,\n    ARRAY(SELECT
+            x FROM UNNEST([celular_disparo_2, celular_disparo_3]) AS x WHERE x IS
+            NOT NULL AND x != celular_disparo) AS others\nfrom final\nwhere celular_disparo
+            is not null\n"
       - cron: "0 10 * * *"
         timezone: America/Sao_Paulo
         active: true
@@ -2575,7 +2589,7 @@ deployments:
           dataset_id: brutos_salesforce
           campaign_name: smspuerperasdisparo12
           data_extension_filename: whatsapp_sms_puerperas_pesquisa5
-          de_columns: ["nome"]
+          de_columns: ["nome", "maternidade"]
           max_dispatch_retries: 0
           sleep_minutes: 5
           whitelist_percentage: 0
@@ -2589,14 +2603,15 @@ deployments:
           whitelist_replace_contacts: true
           query: "-- {pesquisa_id}\nWITH segmentacao_original AS (\n    SELECT\n \
             \       lpad(cast(cpf as string) , 11, '0') as cpf,\n        nome,\n \
-            \       data_alta_internacao,\n        telefones_gestante\n    FROM `rj-sms.projeto_whatsapp.sisare_alta_maternidade`\n\
+            \       nome_maternidade_alta AS maternidade,\n        data_alta_internacao,\n\
+            \        telefones_gestante\n    FROM `rj-sms.projeto_whatsapp.sisare_alta_maternidade`\n\
             \    -- from `rj-crm-registry-dev.brutos_sms.sisare_alta_maternidade_teste`\n\
             \    WHERE cpf is not null\n        and cpf != '00000000000'\n    AND
             CURRENT_DATE('America/Sao_Paulo') in\n        (\n        {datas_internacao}\n\
             \        )\n        and nome_maternidade_alta like '%MARIA AMELIA%'\n
             ),\ntelefones as (\nselect\n    lpad(cast(cpf as string) , 11, '0') as
-            cpf,\n    nome,\n    MAX(data_alta_internacao) as data_alta_internacao,\n\
-            \    MAX(IF(telefone.prioridade = '1', telefone.telefone_valido_whatsapp,
+            cpf,\n    nome,\n    MAX(maternidade) as maternidade,\n    MAX(data_alta_internacao)
+            as data_alta_internacao,\n    MAX(IF(telefone.prioridade = '1', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_1,\n    MAX(IF(telefone.prioridade = '2', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_2,\n    MAX(IF(telefone.prioridade = '3', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_3\nFROM segmentacao_original,\nUNNEST(telefones_gestante)
@@ -2675,10 +2690,11 @@ deployments:
             \    CAST(cpf AS STRING) AS externalId,\n    INITCAP(\n        IF(\n \
             \           ARRAY_LENGTH(SPLIT(nome, ' ')) > 1,\n            CONCAT(SPLIT(nome,
             ' ')[SAFE_OFFSET(0)], ' '),\n            nome\n        )\n    ) AS nome,\n\
-            \    CAST(DATE_DIFF(CURRENT_DATE('America/Sao_Paulo'), DATE(data_alta_internacao),
-            DAY) AS STRING) AS numero_dias,\n    ARRAY(SELECT x FROM UNNEST([celular_disparo_2,
-            celular_disparo_3]) AS x WHERE x IS NOT NULL AND x != celular_disparo)
-            AS others\nfrom final\nwhere celular_disparo is not null\n"
+            \    maternidade,\n    CAST(DATE_DIFF(CURRENT_DATE('America/Sao_Paulo'),
+            DATE(data_alta_internacao), DAY) AS STRING) AS numero_dias,\n    ARRAY(SELECT
+            x FROM UNNEST([celular_disparo_2, celular_disparo_3]) AS x WHERE x IS
+            NOT NULL AND x != celular_disparo) AS others\nfrom final\nwhere celular_disparo
+            is not null\n"
       - cron: "0 10 * * *"
         timezone: America/Sao_Paulo
         active: true
@@ -2700,7 +2716,7 @@ deployments:
           dataset_id: brutos_salesforce
           campaign_name: smspuerperasdisparo152
           data_extension_filename: whatsapp_sms_puerperas_pesquisa7
-          de_columns: ["nome"]
+          de_columns: ["nome", "maternidade"]
           max_dispatch_retries: 0
           sleep_minutes: 5
           whitelist_percentage: 0
@@ -2714,14 +2730,15 @@ deployments:
           whitelist_replace_contacts: true
           query: "-- {pesquisa_id}\nWITH segmentacao_original AS (\n    SELECT\n \
             \       lpad(cast(cpf as string) , 11, '0') as cpf,\n        nome,\n \
-            \       data_alta_internacao,\n        telefones_gestante\n    FROM `rj-sms.projeto_whatsapp.sisare_alta_maternidade`\n\
+            \       nome_maternidade_alta AS maternidade,\n        data_alta_internacao,\n\
+            \        telefones_gestante\n    FROM `rj-sms.projeto_whatsapp.sisare_alta_maternidade`\n\
             \    -- from `rj-crm-registry-dev.brutos_sms.sisare_alta_maternidade_teste`\n\
             \    WHERE cpf is not null\n        and cpf != '00000000000'\n    AND
             CURRENT_DATE('America/Sao_Paulo') in\n        (\n        {datas_internacao}\n\
             \        )\n        and nome_maternidade_alta like '%MARIA AMELIA%'\n
             ),\ntelefones as (\nselect\n    lpad(cast(cpf as string) , 11, '0') as
-            cpf,\n    nome,\n    MAX(data_alta_internacao) as data_alta_internacao,\n\
-            \    MAX(IF(telefone.prioridade = '1', telefone.telefone_valido_whatsapp,
+            cpf,\n    nome,\n    MAX(maternidade) as maternidade,\n    MAX(data_alta_internacao)
+            as data_alta_internacao,\n    MAX(IF(telefone.prioridade = '1', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_1,\n    MAX(IF(telefone.prioridade = '2', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_2,\n    MAX(IF(telefone.prioridade = '3', telefone.telefone_valido_whatsapp,
             NULL)) AS celular_disparo_3\nFROM segmentacao_original,\nUNNEST(telefones_gestante)
@@ -2800,10 +2817,11 @@ deployments:
             \    CAST(cpf AS STRING) AS externalId,\n    INITCAP(\n        IF(\n \
             \           ARRAY_LENGTH(SPLIT(nome, ' ')) > 1,\n            CONCAT(SPLIT(nome,
             ' ')[SAFE_OFFSET(0)], ' '),\n            nome\n        )\n    ) AS nome,\n\
-            \    CAST(DATE_DIFF(CURRENT_DATE('America/Sao_Paulo'), DATE(data_alta_internacao),
-            DAY) AS STRING) AS numero_dias,\n    ARRAY(SELECT x FROM UNNEST([celular_disparo_2,
-            celular_disparo_3]) AS x WHERE x IS NOT NULL AND x != celular_disparo)
-            AS others\nfrom final\nwhere celular_disparo is not null\n"
+            \    maternidade,\n    CAST(DATE_DIFF(CURRENT_DATE('America/Sao_Paulo'),
+            DATE(data_alta_internacao), DAY) AS STRING) AS numero_dias,\n    ARRAY(SELECT
+            x FROM UNNEST([celular_disparo_2, celular_disparo_3]) AS x WHERE x IS
+            NOT NULL AND x != celular_disparo) AS others\nfrom final\nwhere celular_disparo
+            is not null\n"
       - cron: "0 13 * * *"
         timezone: America/Sao_Paulo
         active: false

--- a/pipelines/rj_crm__disparo_template/queries/sms_puerperas_d0_explica_pesquisa.sql
+++ b/pipelines/rj_crm__disparo_template/queries/sms_puerperas_d0_explica_pesquisa.sql
@@ -2,6 +2,7 @@ WITH segmentacao_original AS (
     SELECT
         lpad(cast(cpf as string) , 11, '0') as cpf,
         nome,
+        nome_maternidade_alta AS maternidade,
         data_alta_internacao,
         telefones_gestante,
     FROM `rj-sms.projeto_whatsapp.sisare_alta_maternidade`
@@ -13,9 +14,10 @@ WITH segmentacao_original AS (
             and nome_maternidade_alta like '%MARIA AMELIA%' -- todo: remover comentario
     ),
     telefones as (
-    select 
+    select
         lpad(cast(cpf as string) , 11, '0') as cpf,
         nome,
+        MAX(maternidade) as maternidade,
         MAX(data_alta_internacao) as data_alta_internacao,
         MAX(IF(telefone.prioridade = '1', telefone.telefone_valido_whatsapp, NULL)) AS celular_disparo_1,
         MAX(IF(telefone.prioridade = '2', telefone.telefone_valido_whatsapp, NULL)) AS celular_disparo_2,
@@ -120,6 +122,7 @@ WITH segmentacao_original AS (
                 nome
             )
         ) AS nome,
+        maternidade,
         ARRAY(SELECT x FROM UNNEST([celular_disparo_2, celular_disparo_3]) AS x WHERE x IS NOT NULL AND x != celular_disparo) AS others
     from final
     where celular_disparo is not null

--- a/pipelines/rj_crm__disparo_template/queries/sms_puerperas_pesquisa_template.sql
+++ b/pipelines/rj_crm__disparo_template/queries/sms_puerperas_pesquisa_template.sql
@@ -3,6 +3,7 @@ WITH segmentacao_original AS (
     SELECT
         lpad(cast(cpf as string) , 11, '0') as cpf,
         nome,
+        nome_maternidade_alta AS maternidade,
         data_alta_internacao,
         telefones_gestante
     FROM `rj-sms.projeto_whatsapp.sisare_alta_maternidade`
@@ -19,6 +20,7 @@ telefones as (
 select
     lpad(cast(cpf as string) , 11, '0') as cpf,
     nome,
+    MAX(maternidade) as maternidade,
     MAX(data_alta_internacao) as data_alta_internacao,
     MAX(IF(telefone.prioridade = '1', telefone.telefone_valido_whatsapp, NULL)) AS celular_disparo_1,
     MAX(IF(telefone.prioridade = '2', telefone.telefone_valido_whatsapp, NULL)) AS celular_disparo_2,
@@ -145,6 +147,7 @@ SELECT
             nome
         )
     ) AS nome,
+    maternidade,
     CAST(DATE_DIFF(CURRENT_DATE('America/Sao_Paulo'), DATE(data_alta_internacao), DAY) AS STRING) AS numero_dias,
     ARRAY(SELECT x FROM UNNEST([celular_disparo_2, celular_disparo_3]) AS x WHERE x IS NOT NULL AND x != celular_disparo) AS others
 from final

--- a/pipelines/rj_crm__disparo_template/scheduler_sf.yaml
+++ b/pipelines/rj_crm__disparo_template/scheduler_sf.yaml
@@ -153,7 +153,7 @@ schedules:
         dataset_id: brutos_salesforce
         campaign_name: smspuerperasdisparo25
         data_extension_filename: whatsapp_sms_puerperas_explica_pesquisa
-        de_columns: ["nome"]
+        de_columns: ["nome", "maternidade"]
         max_dispatch_retries: 0
         sleep_minutes: 5
         flow_environment: staging
@@ -199,7 +199,7 @@ schedules:
         dataset_id: brutos_salesforce
         campaign_name: smspuerperasdisparo4v3
         data_extension_filename: whatsapp_sms_puerperas_pesquisa1
-        de_columns: ["nome"]
+        de_columns: ["nome", "maternidade"]
         max_dispatch_retries: 0
         sleep_minutes: 5
         flow_environment: staging
@@ -242,7 +242,7 @@ schedules:
   #       dataset_id: brutos_salesforce
   #       campaign_name: smspuerperasdisparo9
   #       data_extension_filename: whatsapp_sms_puerperas_pesquisa3
-  #       de_columns: ["nome"]
+  #       de_columns: ["nome", "maternidade"]
   #       max_dispatch_retries: 0
   #       sleep_minutes: 5
   #       flow_environment: staging
@@ -280,7 +280,7 @@ schedules:
         dataset_id: brutos_salesforce
         campaign_name: smspuerperadisparo6
         data_extension_filename: whatsapp_sms_puerperas_pesquisa4
-        de_columns: ["nome", "numero_dias"]  # única pesquisa cuja hsm usa a variável numero_dias
+        de_columns: ["nome", "numero_dias", "maternidade"]  # única pesquisa cuja hsm usa a variável numero_dias
         max_dispatch_retries: 0
         sleep_minutes: 5
         flow_environment: staging
@@ -320,7 +320,7 @@ schedules:
         dataset_id: brutos_salesforce
         campaign_name: smspuerperasdisparo12
         data_extension_filename: whatsapp_sms_puerperas_pesquisa5
-        de_columns: ["nome"]
+        de_columns: ["nome", "maternidade"]
         max_dispatch_retries: 0
         sleep_minutes: 5
         flow_environment: staging
@@ -360,7 +360,7 @@ schedules:
   #       dataset_id: brutos_salesforce
   #       campaign_name: smspuerperasdisparo14
   #       data_extension_filename: whatsapp_sms_puerperas_pesquisa6
-  #       de_columns: ["nome"]
+  #       de_columns: ["nome", "maternidade"]
   #       max_dispatch_retries: 0
   #       sleep_minutes: 5
   #       flow_environment: staging
@@ -387,7 +387,6 @@ schedules:
             nome_hsm_anterior_placeholder: smspuerperasdisparo25
             id_hsm_legado_placeholder: 589
             id_hsm_anterior_legado_placeholder: 610
-            id_hsm_legado_placeholder: 589
             pesquisa_id: "Pesquisa 7"
             datas_internacao: "DATE_ADD(DATE(data_alta_internacao), INTERVAL 40 DAY)"
             intervalo_filtro_disparados: 1
@@ -397,7 +396,7 @@ schedules:
         dataset_id: brutos_salesforce
         campaign_name: smspuerperasdisparo152
         data_extension_filename: whatsapp_sms_puerperas_pesquisa7
-        de_columns: ["nome"]
+        de_columns: ["nome", "maternidade"]
         max_dispatch_retries: 0
         sleep_minutes: 5
         flow_environment: staging


### PR DESCRIPTION
## O que muda

As queries de puérperas (`sms_puerperas_d0_explica_pesquisa.sql` e `sms_puerperas_pesquisa_template.sql`) já filtravam por `nome_maternidade_alta` mas não traziam esse campo no resultado — só `sms_puerpera_confirma_agendamento.sql` já fazia isso. Este PR uniformiza: **todas** as queries de puérperas agora sempre trazem `maternidade` no CSV enviado pra Salesforce.

- `queries/sms_puerperas_d0_explica_pesquisa.sql` e `queries/sms_puerperas_pesquisa_template.sql`: adiciona `nome_maternidade_alta AS maternidade` na CTE de segmentação, propaga pela agregação (mesmo padrão de `MAX()` já usado pra `data_alta_internacao`) e inclui no `SELECT` final.
- `scheduler_sf.yaml`: adiciona `"maternidade"` no `de_columns` de todos os schedules ativos de puérperas (D0, D1-D19, D7-D22, D25-D34, D40) e dos dois blocos comentados/inativos (Pesquisa 3 e 6), pra não ficar inconsistente se forem reativados.
- Corrige de quebra uma chave duplicada `id_hsm_legado_placeholder: 589` no bloco D40 — o `ruamel.yaml` recusava carregar o arquivo (`DuplicateKeyError`), travando `build_prefect_yaml.py`.
- `prefect.yaml` regenerado via `python build_prefect_yaml.py --env both`.

## Verificação

Carreguei o `prefect.yaml` gerado e conferi, pra cada schedule ativo de puérperas (staging e prod), que `de_columns` inclui `"maternidade"` **e** que a query resolvida contém o campo — as 6 campanhas × 2 ambientes bateram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)